### PR TITLE
Fix authentication redirect by adding error handling to callback

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -8,7 +8,11 @@ export async function GET(request: Request) {
 
   if (code) {
     const supabase = await createClient()
-    await supabase.auth.exchangeCodeForSession(code)
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    
+    if (error) {
+      return NextResponse.redirect(`${origin}/login?error=${encodeURIComponent(error.message)}`)
+    }
   }
 
   return NextResponse.redirect(`${origin}/dashboard`)


### PR DESCRIPTION
## Problem
The authentication callback was not handling errors from `exchangeCodeForSession`, which could cause the redirect to `/dashboard` to occur before the session was properly established. This resulted in users being redirected back to `/login` by the middleware because they weren't authenticated yet.

## Solution
Added proper error handling to the authentication callback:
- Destructure the result from `exchangeCodeForSession` to check for errors
- If authentication fails, redirect to `/login` with an error message
- Only redirect to `/dashboard` if the session exchange was successful

## Changes
- Updated `app/auth/callback/route.ts` to handle authentication errors gracefully
- Added URL encoding for error messages to safely pass them as query parameters