### PR TITLE
Fix guest user foreign key constraint error

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,7 @@ model User {
 
 model Trip {
   id           String       @id @default(uuid())
-  userId       String       @map("user_id")
+  userId       String?      @map("user_id")
   name         String?
   destination  String
   startDate    DateTime     @map("start_date")
@@ -32,7 +32,7 @@ model Trip {
   notes        String?
   createdAt    DateTime     @default(now()) @map("created_at")
   updatedAt    DateTime     @updatedAt @map("updated_at")
-  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user         User?        @relation(fields: [userId], references: [id], onDelete: Cascade)
   packingLists PackingList[]
   @@index([userId])
   @@index([startDate])


### PR DESCRIPTION
## Problem
When creating trips in guest mode, Prisma throws a foreign key constraint error:
```
Foreign key constraint violated: `trips_user_id_fkey (index)`
```

This happens because guest user IDs don't exist in the `users` table, but the `trips` table has a required foreign key relationship to `users`.

## Solution
Make the user relationship optional by:
- Changing `Trip.userId` from `String` to `String?` (nullable)
- Changing `Trip.user` relation from `User` to `User?` (optional)

This allows trips to be created without a corresponding user record in the database.

## Changes
- Updated `prisma/schema.prisma` to make the Trip → User relationship optional

## Migration Required
After merging, run:
```bash
npx prisma db push
```
Or create a migration:
```bash
npx prisma migrate dev --name make-trip-user-optional
```

## Related PRs
- PR #2: Add guest mode middleware
- PR #3: Support guest mode in server actions

All three PRs should be merged for full guest mode functionality.