### PR TITLE
Fix trips.map error in dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -49,8 +49,10 @@ export default function DashboardPage() {
       setUser(session.user)
 
       try {
-        const userTrips = await getUserTrips()
-        setTrips(userTrips || [])
+        const result = await getUserTrips()
+        if (result.trips) {
+          setTrips(result.trips)
+        }
       } catch (e) {
         console.error('Failed to load trips:', e)
       }
@@ -113,7 +115,7 @@ export default function DashboardPage() {
             <p className="text-gray-500 mt-1">Manage your packing lists</p>
           </div>
           <Link
-            href="/trip/new"
+            href="/dashboard/new"
             className="bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-colors"
           >
             + New Trip
@@ -126,7 +128,7 @@ export default function DashboardPage() {
             <h2 className="text-xl font-semibold text-gray-700 mb-2">No trips yet</h2>
             <p className="text-gray-500 mb-6">Create your first trip to get started with smart packing lists.</p>
             <Link
-              href="/trip/new"
+              href="/dashboard/new"
               className="bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition-colors"
             >
               Create Your First Trip


### PR DESCRIPTION
## Problem
Dashboard throws error: `TypeError: trips.map is not a function`

This happens because `getUserTrips()` returns an object `{ trips: [...] }` but the dashboard code was treating the entire result as an array.

## Solution
Properly destructure the result from `getUserTrips()`:

**Before:**
```typescript
const userTrips = await getUserTrips()
setTrips(userTrips || [])
```

**After:**
```typescript
const result = await getUserTrips()
if (result.trips) {
  setTrips(result.trips)
}
```

## Additional Fix
- Changed "New Trip" link from `/trip/new` to `/dashboard/new` to match the correct route structure

## Testing
1. Log in to the app
2. Navigate to dashboard
3. Should see trips list without errors
4. Click "New Trip" button should navigate correctly