### PR TITLE
fix: resolve Unauthorized error for logged-in users caused by guest_mode cookie priority

### DIFF
--- a/actions/packing.actions.ts
+++ b/actions/packing.actions.ts
@@ -5,18 +5,21 @@ import { cookies } from 'next/headers'
 import { prisma } from '@/lib/prisma'
 import { createClient } from '@/lib/supabase/server'
 
+// Always checks Supabase auth first so that logged-in users are never
+// accidentally blocked by a stale guest_mode cookie.
 async function getAuthenticatedUserId(): Promise<string | null> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (user) return user.id
+
+  // No authenticated session — fall back to guest mode
   const cookieStore = await cookies()
   const isGuestMode = cookieStore.get('guest_mode')?.value === 'true'
-
   if (isGuestMode) {
-    // In guest mode, the guest_user_id must be set client-side before calling any server actions
     return cookieStore.get('guest_user_id')?.value || null
   }
 
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  return user?.id || null
+  return null
 }
 
 export async function toggleItemPacked(itemId: string, isPacked: boolean, tripId?: string) {

--- a/actions/trip.actions.ts
+++ b/actions/trip.actions.ts
@@ -8,22 +8,24 @@ import { generatePackingList } from '@/utils/packingGenerator'
 import { CreateTripInput, TripType } from '@/types'
 import { getTripDuration } from '@/lib/utils'
 
-// Helper to get user ID (authenticated or guest)
+// Helper to get user ID (authenticated or guest).
+// Always checks Supabase auth first so that logged-in users are never
+// accidentally treated as guests due to a stale guest_mode cookie.
 async function getUserId(): Promise<string | null> {
-  const cookieStore = await cookies()
-  const isGuestMode = cookieStore.get('guest_mode')?.value === 'true'
-
-  if (isGuestMode) {
-    // Guest user ID must be set client-side (e.g. via document.cookie) before calling server actions.
-    // Server actions cannot set cookies, so we rely on the client to persist the guest ID.
-    const guestId = cookieStore.get('guest_user_id')?.value
-    if (!guestId) return null
-    return guestId
-  }
-
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
-  return user?.id || null
+  if (user) return user.id
+
+  // No authenticated session — fall back to guest mode
+  const cookieStore = await cookies()
+  const isGuestMode = cookieStore.get('guest_mode')?.value === 'true'
+  if (isGuestMode) {
+    // Guest user ID must be set client-side before calling server actions.
+    // Server actions cannot set cookies, so the client must persist this.
+    return cookieStore.get('guest_user_id')?.value || null
+  }
+
+  return null
 }
 
 export async function createTrip(input: CreateTripInput) {

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -6,11 +6,13 @@ export async function updateSession(request: NextRequest) {
     request,
   })
 
-  // Check for guest mode query parameter
+  // Check for guest mode query parameter or existing cookie
   const guestMode = request.nextUrl.searchParams.get('guest') === 'true'
   const hasGuestCookie = request.cookies.get('guest_mode')?.value === 'true'
 
-  // If guest mode is enabled, set a cookie and skip auth
+  // Set/renew the guest_mode cookie if needed, but do NOT return early.
+  // We must still run the Supabase session refresh below so that auth tokens
+  // stay valid for users who are (or later become) logged in.
   if (guestMode || hasGuestCookie) {
     supabaseResponse.cookies.set('guest_mode', 'true', {
       path: '/',
@@ -18,7 +20,6 @@ export async function updateSession(request: NextRequest) {
       httpOnly: true,
       sameSite: 'lax',
     })
-    return supabaseResponse
   }
 
   const supabase = createServerClient(
@@ -36,6 +37,15 @@ export async function updateSession(request: NextRequest) {
           supabaseResponse = NextResponse.next({
             request,
           })
+          // Re-apply the guest_mode cookie since we just created a new response
+          if (guestMode || hasGuestCookie) {
+            supabaseResponse.cookies.set('guest_mode', 'true', {
+              path: '/',
+              maxAge: 60 * 60 * 24 * 7,
+              httpOnly: true,
+              sameSite: 'lax',
+            })
+          }
           cookiesToSet.forEach(({ name, value, options }) =>
             supabaseResponse.cookies.set(name, value, options)
           )
@@ -44,23 +54,9 @@ export async function updateSession(request: NextRequest) {
     }
   )
 
-  // IMPORTANT: Refresh session if expired - required for Server Components
-  // This ensures the session cookies are updated and persisted
-  const { data: { user } } = await supabase.auth.getUser()
-
-  // Optional: redirect to login if accessing protected routes without auth
-  // Uncomment if you want server-side protection:
-  // if (
-  //   !user &&
-  //   !request.nextUrl.pathname.startsWith('/login') &&
-  //   !request.nextUrl.pathname.startsWith('/auth') &&
-  //   !request.nextUrl.pathname.startsWith('/_next') &&
-  //   !request.nextUrl.pathname.startsWith('/api')
-  // ) {
-  //   const url = request.nextUrl.clone()
-  //   url.pathname = '/login'
-  //   return NextResponse.redirect(url)
-  // }
+  // IMPORTANT: Always refresh the session, even in guest mode.
+  // This keeps auth tokens valid for logged-in users and is a no-op for guests.
+  await supabase.auth.getUser()
 
   return supabaseResponse
 }


### PR DESCRIPTION
## Problem

Logged-in users were receiving `{"error":"Unauthorized"}` when trying to create a trip (and on all other server actions). This was caused by **two compounding bugs** in the auth flow:

---

### Bug 1 — Middleware skipped session refresh when `guest_mode` cookie was present

**File:** `lib/supabase/middleware.ts`

The old code had an early `return` when `guest_mode=true`:
```ts
// BEFORE (broken)
if (guestMode || hasGuestCookie) {
  supabaseResponse.cookies.set('guest_mode', 'true', { ... })
  return supabaseResponse // ← skipped supabase.auth.getUser() entirely
}
```

If a user had ever visited `/?guest=true`, they'd carry a `guest_mode` cookie for **7 days**. Every subsequent request would skip the Supabase session refresh, causing auth tokens to go stale — so `supabase.auth.getUser()` in server actions would return no user.

**Fix:** Removed the early return. The guest cookie is still set/renewed, but the middleware now always runs `supabase.auth.getUser()` to keep tokens valid.

---

### Bug 2 — `getUserId()` checked `guest_mode` cookie before Supabase auth

**Files:** `actions/trip.actions.ts`, `actions/packing.actions.ts`

The old priority order was:
```
1. Is guest_mode=true? → return guest_user_id (or null if missing)
2. Otherwise → check Supabase
```

So any user with a `guest_mode=true` cookie but no `guest_user_id` (i.e. every real logged-in user who had previously demo'd the app) would get `null` returned and see `Unauthorized`.

**Fix:** Reversed the priority:
```
1. Check Supabase first → if authenticated user exists, return their ID
2. No session → fall back to guest_user_id cookie
```

Authenticated users now always take precedence, regardless of what cookies are present.

---

## Files Changed

| File | Change |
|---|---|
| `lib/supabase/middleware.ts` | Removed early return on guest mode; session refresh always runs |
| `actions/trip.actions.ts` | `getUserId()` checks Supabase first, falls back to guest |
| `actions/packing.actions.ts` | `getAuthenticatedUserId()` checks Supabase first, falls back to guest |
