### PR TITLE
fix: add getSession() fallback and lazy Prisma User upsert to resolve…

### DIFF
--- a/actions/packing.actions.ts
+++ b/actions/packing.actions.ts
@@ -5,18 +5,35 @@ import { cookies } from 'next/headers'
 import { prisma } from '@/lib/prisma'
 import { createClient } from '@/lib/supabase/server'
 
-// Always checks Supabase auth first so that logged-in users are never
-// accidentally blocked by a stale guest_mode cookie.
+/**
+ * Returns any non-null user identifier (Supabase user.id or guest_user_id)
+ * sufficient to verify the caller is authenticated.
+ *
+ * Priority:
+ * 1. supabase.auth.getUser()  — validates JWT with Supabase API
+ * 2. supabase.auth.getSession() — reads local cookie (fallback for paused projects)
+ * 3. guest_user_id cookie
+ */
 async function getAuthenticatedUserId(): Promise<string | null> {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (user) return user.id
 
-  // No authenticated session — fall back to guest mode
+  // 1. Try getUser() first
+  try {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (user) return user.id
+  } catch {}
+
+  // 2. Fall back to getSession()
+  try {
+    const { data: { session } } = await supabase.auth.getSession()
+    if (session?.user) return session.user.id
+  } catch {}
+
+  // 3. Fall back to guest mode
   const cookieStore = await cookies()
   const isGuestMode = cookieStore.get('guest_mode')?.value === 'true'
   if (isGuestMode) {
-    return cookieStore.get('guest_user_id')?.value || null
+    return cookieStore.get('guest_user_id')?.value ?? null
   }
 
   return null

--- a/actions/trip.actions.ts
+++ b/actions/trip.actions.ts
@@ -8,21 +8,64 @@ import { generatePackingList } from '@/utils/packingGenerator'
 import { CreateTripInput, TripType } from '@/types'
 import { getTripDuration } from '@/lib/utils'
 
-// Helper to get user ID (authenticated or guest).
-// Always checks Supabase auth first so that logged-in users are never
-// accidentally treated as guests due to a stale guest_mode cookie.
+/**
+ * Returns the PRISMA User.id (not the Supabase auth UUID) so that the
+ * Trip.userId foreign key constraint is satisfied.
+ *
+ * Priority:
+ * 1. supabase.auth.getUser()  — validates JWT with Supabase API (most secure)
+ * 2. supabase.auth.getSession() — reads local cookie, no network call
+ *    (fallback when Supabase project is paused or API is unreachable)
+ * 3. guest_user_id cookie      — for demo/guest users
+ *
+ * When a Supabase user is found, a Prisma User row is upserted so that
+ * the Trip.userId FK constraint (which references User.id) is satisfied.
+ */
 async function getUserId(): Promise<string | null> {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (user) return user.id
 
-  // No authenticated session — fall back to guest mode
+  let authUser: any = null
+
+  // 1. Try getUser() — validates with Supabase API
+  try {
+    const { data: { user } } = await supabase.auth.getUser()
+    authUser = user
+  } catch {}
+
+  // 2. Fall back to getSession() if getUser() failed (e.g. project paused)
+  if (!authUser) {
+    try {
+      const { data: { session } } = await supabase.auth.getSession()
+      authUser = session?.user ?? null
+    } catch {}
+  }
+
+  if (authUser) {
+    // Upsert the Prisma User row so Trip.userId FK constraint is satisfied.
+    // Trip.userId references User.id (Prisma UUID), not supabase user.id.
+    const prismaUser = await prisma.user.upsert({
+      where: { supabaseId: authUser.id },
+      create: {
+        supabaseId: authUser.id,
+        email: authUser.email ?? '',
+        name: authUser.user_metadata?.full_name ?? authUser.user_metadata?.name ?? null,
+        avatarUrl: authUser.user_metadata?.avatar_url ?? null,
+        authProvider: authUser.app_metadata?.provider ?? 'email',
+      },
+      update: {
+        email: authUser.email ?? '',
+        name: authUser.user_metadata?.full_name ?? authUser.user_metadata?.name ?? null,
+        avatarUrl: authUser.user_metadata?.avatar_url ?? null,
+      },
+    })
+    return prismaUser.id
+  }
+
+  // 3. Fall back to guest mode
   const cookieStore = await cookies()
   const isGuestMode = cookieStore.get('guest_mode')?.value === 'true'
   if (isGuestMode) {
-    // Guest user ID must be set client-side before calling server actions.
-    // Server actions cannot set cookies, so the client must persist this.
-    return cookieStore.get('guest_user_id')?.value || null
+    return cookieStore.get('guest_user_id')?.value ?? null
   }
 
   return null

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
 import { NextResponse } from 'next/server'
 
 export async function GET(request: Request) {
@@ -8,10 +9,35 @@ export async function GET(request: Request) {
 
   if (code) {
     const supabase = await createClient()
-    const { error } = await supabase.auth.exchangeCodeForSession(code)
-    
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+
     if (error) {
       return NextResponse.redirect(`${origin}/login?error=${encodeURIComponent(error.message)}`)
+    }
+
+    // Eagerly upsert the Prisma User row on login so the Trip.userId FK
+    // constraint is always satisfied before the user hits any server action.
+    if (data?.user) {
+      try {
+        await prisma.user.upsert({
+          where: { supabaseId: data.user.id },
+          create: {
+            supabaseId: data.user.id,
+            email: data.user.email ?? '',
+            name: data.user.user_metadata?.full_name ?? data.user.user_metadata?.name ?? null,
+            avatarUrl: data.user.user_metadata?.avatar_url ?? null,
+            authProvider: data.user.app_metadata?.provider ?? 'email',
+          },
+          update: {
+            email: data.user.email ?? '',
+            name: data.user.user_metadata?.full_name ?? data.user.user_metadata?.name ?? null,
+            avatarUrl: data.user.user_metadata?.avatar_url ?? null,
+          },
+        })
+      } catch (e) {
+        // Non-fatal: getUserId() will retry the upsert on the next action call
+        console.error('Failed to upsert user on auth callback:', e)
+      }
     }
   }
 


### PR DESCRIPTION
… Unauthorized on createTrip

Two bugs were causing Unauthorized for logged-in users:

1. supabase.auth.getUser() makes a live network call to validate the JWT. If the Supabase project is paused (free tier) or any network issue occurs, it returns null even though a valid session exists in cookies. The dashboard never hit this because it uses getSession() (local cookie read, no API call). Added getSession() as a fallback in both getUserId() and getAuthenticatedUserId().

2. Trip.userId is a FK referencing User.id (a Prisma-generated UUID), NOT the Supabase auth user.id. The code was passing supabase_user.id directly as userId, which would fail with P2003 because no Prisma User row existed. Nothing in the codebase was creating these rows. Fixed by lazily upserting a Prisma User record inside getUserId(), keyed on supabaseId, and returning the Prisma User.id for trip creation.

3. Updated auth callback to eagerly upsert the Prisma User on login so the record exists before any server action fires.