### PR TITLE
fix: URL-decode cookie values in createServerClient (@supabase/ssr@0.1.0 bug)

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -10,7 +10,17 @@ export async function createClient() {
     {
       cookies: {
         getAll() {
-          return cookieStore.getAll()
+          // @supabase/ssr@0.1.0 stores the session as URL-encoded JSON.
+          // Next.js returns the raw (still URL-encoded) cookie value from
+          // the Cookie header. We must decode it before passing to the
+          // Supabase client so JSON.parse() inside the library succeeds.
+          return cookieStore.getAll().map(({ name, value }) => {
+            try {
+              return { name, value: decodeURIComponent(value) }
+            } catch {
+              return { name, value }
+            }
+          })
         },
         setAll(cookiesToSet: { name: string; value: string; options?: Record<string, unknown> }[]) {
           try {
@@ -18,8 +28,8 @@ export async function createClient() {
               cookieStore.set(name, value, options)
             )
           } catch {
-            // setAll called from a Server Component - can be ignored
-            // if middleware is refreshing user sessions
+            // setAll called from a Server Component — safe to ignore
+            // because the middleware handles session refresh
           }
         },
       },


### PR DESCRIPTION
## The Actual Root Cause

This is a **one-line fix** that resolves the persistent `Unauthorized` error.

`@supabase/ssr@0.1.0`'s `createBrowserClient` stores the session as **URL-encoded JSON** in the cookie:

```
sb-nyqfcrkerbhefqjcuvfw-auth-token = %7B%22access_token%22%3A%22eyJ...%22%7D
```

When a Server Action runs, Next.js reads the raw `Cookie` header and returns the value **still URL-encoded** via `cookies().getAll()`. The Supabase server client receives `%7B%22access_token%22...` and tries `JSON.parse()` on it — which fails silently because `%7B` is not `{`.

Result: both `supabase.auth.getUser()` and `supabase.auth.getSession()` return `null` → every server action hits `Unauthorized`.

**The dashboard never hits this** because `createBrowserClient` reads from `document.cookie`, and browsers automatically URL-decode cookie values when reading them via `document.cookie`. The browser client works fine; only the server client is broken.

---

## The Fix

In `lib/supabase/server.ts`, wrap `getAll()` to call `decodeURIComponent()` on every cookie value before passing it to the Supabase client:

```ts
getAll() {
  return cookieStore.getAll().map(({ name, value }) => {
    try {
      return { name, value: decodeURIComponent(value) }
    } catch {
      return { name, value }  // fallback if not URL-encoded
    }
  })
}
```

`decodeURIComponent` is a no-op on values that aren't URL-encoded (plain JSON is returned unchanged), so this is fully safe for all cookie values.

---

## Files Changed

| File | Change |
|---|---|
| `lib/supabase/server.ts` | `getAll()` now URL-decodes cookie values before returning them |
