### PR TITLE
fix: auto-redirect on signup when email confirmation is disabled

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -21,16 +21,27 @@ export default function LoginPage() {
     const supabase = createClient()
 
     if (isSignUp) {
-      const { error } = await supabase.auth.signUp({
+      const { data, error } = await supabase.auth.signUp({
         email,
         password,
         options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
       })
+
       if (error) {
         setError(error.message)
-      } else {
-        setMessage('Check your email for a confirmation link!')
+        setLoading(false)
+        return
       }
+
+      // If email confirmation is disabled, signUp returns a valid session.
+      // Redirect immediately to dashboard (the auth callback will upsert the Prisma User).
+      if (data?.session) {
+        window.location.href = '/dashboard'
+        return
+      }
+
+      // Email confirmation is enabled — user must click the link in their email
+      setMessage('Check your email for a confirmation link!')
     } else {
       const { error } = await supabase.auth.signInWithPassword({ email, password })
       if (error) {


### PR DESCRIPTION
## Problem

When email confirmation is disabled in the Supabase dashboard (Authentication → Email Auth → uncheck "Enable email confirmations"), `signUp()` returns a **valid session immediately** — the user is signed in right away.

But the old code always showed:
> "Check your email for a confirmation link!"

...and never redirected. The user had to manually click "Sign in" with the same credentials they just signed up with.

---

## Fix

Check if `signUp()` returned a `session`. If yes → redirect to `/dashboard` immediately. If no session (email confirmation still enabled) → show the email confirmation message.

```ts
if (data?.session) {
  window.location.href = '/dashboard'  // email confirmation disabled
  return
}
setMessage('Check your email for a confirmation link!')  // email confirmation enabled
```

This makes the signup flow seamless when email confirmation is off, while preserving the existing behavior when it's on.

---

## How to Disable Email Confirmation

1. Go to [Supabase Dashboard → Authentication → Email Auth](https://supabase.com/dashboard/project/nyqfcrkerbhefqjcuvfw/auth/settings)
2. Uncheck **"Enable email confirmations"**
3. Save

After merging this PR, new signups will be auto-signed-in with no email verification step.

---

## Files Changed

| File | Change |
|---|---|
| `app/(auth)/login/page.tsx` | Check `data?.session` after `signUp()` and redirect if present |
