### PR TITLE
fix: upgrade @supabase/ssr from 0.1.0 to 0.9.0 to fix cookie parsing

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -10,19 +10,9 @@ export async function createClient() {
     {
       cookies: {
         getAll() {
-          // @supabase/ssr@0.1.0 stores the session as URL-encoded JSON.
-          // Next.js returns the raw (still URL-encoded) cookie value from
-          // the Cookie header. We must decode it before passing to the
-          // Supabase client so JSON.parse() inside the library succeeds.
-          return cookieStore.getAll().map(({ name, value }) => {
-            try {
-              return { name, value: decodeURIComponent(value) }
-            } catch {
-              return { name, value }
-            }
-          })
+          return cookieStore.getAll()
         },
-        setAll(cookiesToSet: { name: string; value: string; options?: Record<string, unknown> }[]) {
+        setAll(cookiesToSet) {
           try {
             cookiesToSet.forEach(({ name, value, options }) =>
               cookieStore.set(name, value, options)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@prisma/client": "^5.9.1",
-    "@supabase/ssr": "^0.1.0",
+    "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.49.4",
     "autoprefixer": "^10.0.1",
     "framer-motion": "^11.0.5",


### PR DESCRIPTION
## Root Cause

`@supabase/ssr@0.1.0` has a **critical bug** where cookies are stored URL-encoded but not properly decoded when read back. This causes `getSession()` to return `null` even when a valid session cookie exists.

The debug logs proved it:
```
[getUserId] All cookies from Next.js: sb-nyqfcrkerbhefqjcuvfw-auth-token
[getUserId] getSession() full result: { "data": { "session": null }, "error": null }
```

The cookie was there, but Supabase couldn't parse it.

---

## The Fix

**Upgrade to `@supabase/ssr@0.9.0`** (latest stable). Version 0.4.0+ completely rewrote cookie handling:

> "We've finished internal tests on the new changes... Make sure you move to `getAll` and `setAll` as soon as you are able. This is especially important for Next.js users inside their `middleware.ts` file. **This is the biggest source of problems, and this update significantly reduces the issues!**"
> — [Supabase SSR v0.4.0 release notes](https://github.com/orgs/supabase/discussions/27037#discussioncomment-9813850)

The new version:
- ✅ Handles cookie encoding/decoding natively
- ✅ Fixes URL-encoding bugs
- ✅ Improves cookie chunking for large sessions
- ✅ Better edge case handling

---

## Changes

| File | Change |
|---|---|
| `package.json` | Upgrade `@supabase/ssr` from `^0.1.0` → `^0.9.0` |
| `lib/supabase/server.ts` | Remove manual `decodeURIComponent()` workaround (no longer needed) |

---

## After Merging

1. **Locally:** Run `npm install` to upgrade the package
2. **Sign out and sign back in** once to get a fresh cookie in the new format
3. Try creating a trip — it should work immediately

Vercel will auto-install the new version on deploy.
