### PR TITLE
Add luggage/bag management and item assignment

### DIFF
--- a/actions/luggage.actions.ts
+++ b/actions/luggage.actions.ts
@@ -1,0 +1,191 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { cookies } from 'next/headers'
+import { prisma } from '@/lib/prisma'
+import { createClient } from '@/lib/supabase/server'
+import type { CreateLuggageInput, UpdateLuggageInput } from '@/types/luggage'
+
+async function getAuthenticatedUserId(): Promise<string | null> {
+  const supabase = await createClient()
+
+  try {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (user) return user.id
+  } catch {}
+
+  try {
+    const { data: { session } } = await supabase.auth.getSession()
+    if (session?.user) return session.user.id
+  } catch {}
+
+  const cookieStore = await cookies()
+  const isGuestMode = cookieStore.get('guest_mode')?.value === 'true'
+  if (isGuestMode) {
+    return cookieStore.get('guest_user_id')?.value ?? null
+  }
+
+  return null
+}
+
+export async function getUserLuggage() {
+  try {
+    const userId = await getAuthenticatedUserId()
+    if (!userId) return { error: 'Unauthorized' }
+
+    const luggage = await prisma.luggage.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    })
+
+    return { success: true, luggage }
+  } catch (error) {
+    return { error: 'Failed to fetch luggage' }
+  }
+}
+
+export async function createLuggage(input: CreateLuggageInput) {
+  try {
+    const userId = await getAuthenticatedUserId()
+    if (!userId) return { error: 'Unauthorized' }
+
+    const luggage = await prisma.luggage.create({
+      data: {
+        userId,
+        name: input.name,
+        type: input.type,
+        capacity: input.capacity,
+      },
+    })
+
+    revalidatePath('/luggage')
+    return { success: true, luggage }
+  } catch (error) {
+    return { error: 'Failed to create luggage' }
+  }
+}
+
+export async function updateLuggage(id: string, input: UpdateLuggageInput) {
+  try {
+    const userId = await getAuthenticatedUserId()
+    if (!userId) return { error: 'Unauthorized' }
+
+    const luggage = await prisma.luggage.findUnique({ where: { id } })
+    if (!luggage || luggage.userId !== userId) {
+      return { error: 'Luggage not found' }
+    }
+
+    const updated = await prisma.luggage.update({
+      where: { id },
+      data: input,
+    })
+
+    revalidatePath('/luggage')
+    return { success: true, luggage: updated }
+  } catch (error) {
+    return { error: 'Failed to update luggage' }
+  }
+}
+
+export async function deleteLuggage(id: string) {
+  try {
+    const userId = await getAuthenticatedUserId()
+    if (!userId) return { error: 'Unauthorized' }
+
+    const luggage = await prisma.luggage.findUnique({ where: { id } })
+    if (!luggage || luggage.userId !== userId) {
+      return { error: 'Luggage not found' }
+    }
+
+    await prisma.luggage.delete({ where: { id } })
+
+    revalidatePath('/luggage')
+    return { success: true }
+  } catch (error) {
+    return { error: 'Failed to delete luggage' }
+  }
+}
+
+export async function getTripLuggage(tripId: string) {
+  try {
+    const userId = await getAuthenticatedUserId()
+    if (!userId) return { error: 'Unauthorized' }
+
+    const tripLuggages = await prisma.tripLuggage.findMany({
+      where: { tripId, isActive: true },
+      include: {
+        luggage: true,
+        packingItems: true,
+      },
+    })
+
+    return { success: true, tripLuggages }
+  } catch (error) {
+    return { error: 'Failed to fetch trip luggage' }
+  }
+}
+
+export async function addLuggageToTrip(tripId: string, luggageId: string) {
+  try {
+    const userId = await getAuthenticatedUserId()
+    if (!userId) return { error: 'Unauthorized' }
+
+    const existing = await prisma.tripLuggage.findUnique({
+      where: { tripId_luggageId: { tripId, luggageId } },
+    })
+
+    if (existing) {
+      const updated = await prisma.tripLuggage.update({
+        where: { id: existing.id },
+        data: { isActive: true },
+        include: { luggage: true },
+      })
+      revalidatePath(`/trip/${tripId}`)
+      return { success: true, tripLuggage: updated }
+    }
+
+    const tripLuggage = await prisma.tripLuggage.create({
+      data: { tripId, luggageId, isActive: true },
+      include: { luggage: true },
+    })
+
+    revalidatePath(`/trip/${tripId}`)
+    return { success: true, tripLuggage }
+  } catch (error) {
+    return { error: 'Failed to add luggage to trip' }
+  }
+}
+
+export async function removeLuggageFromTrip(tripId: string, luggageId: string) {
+  try {
+    const userId = await getAuthenticatedUserId()
+    if (!userId) return { error: 'Unauthorized' }
+
+    await prisma.tripLuggage.updateMany({
+      where: { tripId, luggageId },
+      data: { isActive: false },
+    })
+
+    revalidatePath(`/trip/${tripId}`)
+    return { success: true }
+  } catch (error) {
+    return { error: 'Failed to remove luggage from trip' }
+  }
+}
+
+export async function assignItemToLuggage(packingItemId: string, tripLuggageId: string | null, tripId?: string) {
+  try {
+    const userId = await getAuthenticatedUserId()
+    if (!userId) return { error: 'Unauthorized' }
+
+    await prisma.packingItem.update({
+      where: { id: packingItemId },
+      data: { tripLuggageId },
+    })
+
+    if (tripId) revalidatePath(`/trip/${tripId}`)
+    return { success: true }
+  } catch (error) {
+    return { error: 'Failed to assign item to luggage' }
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   updatedAt           DateTime            @updatedAt @map("updated_at")
   trips               Trip[]
   inventoryCategories InventoryCategory[]
+  luggage             Luggage[]
 
   @@map("users")
 }
@@ -36,6 +37,7 @@ model Trip {
   updatedAt    DateTime      @updatedAt @map("updated_at")
   user         User?         @relation(fields: [userId], references: [id], onDelete: Cascade)
   packingLists PackingList[]
+  tripLuggages TripLuggage[]
 
   @@index([userId])
   @@index([startDate])
@@ -68,16 +70,19 @@ model Category {
 }
 
 model PackingItem {
-  id         String   @id @default(uuid())
-  categoryId String   @map("category_id")
-  name       String
-  quantity   Int      @default(1)
-  isPacked   Boolean  @default(false) @map("is_packed")
-  isCustom   Boolean  @default(false) @map("is_custom")
-  order      Int      @default(0)
-  category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  id            String       @id @default(uuid())
+  categoryId    String       @map("category_id")
+  name          String
+  quantity      Int          @default(1)
+  isPacked      Boolean      @default(false) @map("is_packed")
+  isCustom      Boolean      @default(false) @map("is_custom")
+  order         Int          @default(0)
+  tripLuggageId String?      @map("trip_luggage_id")
+  category      Category     @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  tripLuggage   TripLuggage? @relation(fields: [tripLuggageId], references: [id], onDelete: SetNull)
 
   @@index([categoryId])
+  @@index([tripLuggageId])
   @@map("packing_items")
 }
 
@@ -109,4 +114,36 @@ model InventoryItem {
 
   @@index([categoryId])
   @@map("inventory_items")
+}
+
+model Luggage {
+  id           String        @id @default(uuid())
+  userId       String        @map("user_id")
+  name         String
+  type         String
+  capacity     Int?
+  createdAt    DateTime      @default(now()) @map("created_at")
+  updatedAt    DateTime      @updatedAt @map("updated_at")
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tripLuggages TripLuggage[]
+
+  @@index([userId])
+  @@map("luggage")
+}
+
+model TripLuggage {
+  id           String        @id @default(uuid())
+  tripId       String        @map("trip_id")
+  luggageId    String        @map("luggage_id")
+  isActive     Boolean       @default(true) @map("is_active")
+  createdAt    DateTime      @default(now()) @map("created_at")
+  updatedAt    DateTime      @updatedAt @map("updated_at")
+  trip         Trip          @relation(fields: [tripId], references: [id], onDelete: Cascade)
+  luggage      Luggage       @relation(fields: [luggageId], references: [id], onDelete: Cascade)
+  packingItems PackingItem[]
+
+  @@unique([tripId, luggageId])
+  @@index([tripId])
+  @@index([luggageId])
+  @@map("trip_luggage")
 }

--- a/types/luggage.ts
+++ b/types/luggage.ts
@@ -1,0 +1,47 @@
+export type LuggageType = 'backpack' | 'checked' | 'carry-on' | 'trunk' | 'other'
+
+export interface Luggage {
+  id: string
+  userId: string
+  name: string
+  type: LuggageType
+  capacity?: number
+  createdAt: Date
+  updatedAt: Date
+  tripLuggages?: TripLuggage[]
+}
+
+export interface TripLuggage {
+  id: string
+  tripId: string
+  luggageId: string
+  isActive: boolean
+  createdAt: Date
+  updatedAt: Date
+  luggage: Luggage
+  packingItems?: PackingItemWithLuggage[]
+}
+
+export interface PackingItemWithLuggage {
+  id: string
+  categoryId: string
+  name: string
+  quantity: number
+  isPacked: boolean
+  isCustom: boolean
+  order: number
+  tripLuggageId?: string
+  tripLuggage?: TripLuggage
+}
+
+export interface CreateLuggageInput {
+  name: string
+  type: LuggageType
+  capacity?: number
+}
+
+export interface UpdateLuggageInput {
+  name?: string
+  type?: LuggageType
+  capacity?: number
+}


### PR DESCRIPTION
## Overview
Adds the ability to manage luggage/bags (like a 20L Aer backpack, Rimowa check-in, or Rimowa trunk) and assign packing items to specific bags for each trip.

## Changes

### Database Schema (`prisma/schema.prisma`)
- **New `Luggage` model**: Stores user's luggage library (name, type, capacity)
- **New `TripLuggage` model**: Junction table linking luggage to specific trips with active/inactive status
- **Updated `PackingItem`**: Added optional `tripLuggageId` to assign items to specific bags
- **Updated `Trip`**: Added `tripLuggages` relation

### Types (`types/luggage.ts`)
- `LuggageType`: backpack, checked, carry-on, trunk, other
- `Luggage`, `TripLuggage`, `PackingItemWithLuggage` interfaces
- Input types for create/update operations

### Server Actions (`actions/luggage.actions.ts`)
- `getUserLuggage()`: Fetch user's luggage library
- `createLuggage()`, `updateLuggage()`, `deleteLuggage()`: CRUD operations
- `getTripLuggage()`: Get active luggage for a trip
- `addLuggageToTrip()`, `removeLuggageFromTrip()`: Manage trip-luggage associations
- `assignItemToLuggage()`: Assign packing items to specific bags

## User Flow

1. **Create luggage library**: User adds their bags (e.g., "20L Aer Pro Pack", "Rimowa Check-In L", "Rimowa Trunk")
2. **Select bags for trip**: When planning a trip, user selects which bags to bring (✓ Aer, ✓ Check-In, ✗ Trunk)
3. **Assign items to bags**: While packing, user assigns each item to a specific bag ("Laptop → Aer", "Shoes → Check-In")
4. **View by bag**: See item counts per bag and filter/group items by luggage

## Next Steps (Future PRs)
- UI components for luggage library management
- Trip luggage selector component
- Enhanced PackingListSection with luggage assignment dropdowns
- Luggage management page at `/luggage`
- Visual indicators and filtering by bag

## Migration Required
```bash
npx prisma migrate dev --name add_luggage_management
npx prisma generate
```