### PR TITLE
HOTFIX: Revert schema changes to fix production 404 errors

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,7 +18,6 @@ model User {
   updatedAt           DateTime            @updatedAt @map("updated_at")
   trips               Trip[]
   inventoryCategories InventoryCategory[]
-  luggage             Luggage[]
 
   @@map("users")
 }
@@ -37,7 +36,6 @@ model Trip {
   updatedAt    DateTime      @updatedAt @map("updated_at")
   user         User?         @relation(fields: [userId], references: [id], onDelete: Cascade)
   packingLists PackingList[]
-  tripLuggages TripLuggage[]
 
   @@index([userId])
   @@index([startDate])
@@ -70,19 +68,16 @@ model Category {
 }
 
 model PackingItem {
-  id            String       @id @default(uuid())
-  categoryId    String       @map("category_id")
-  name          String
-  quantity      Int          @default(1)
-  isPacked      Boolean      @default(false) @map("is_packed")
-  isCustom      Boolean      @default(false) @map("is_custom")
-  order         Int          @default(0)
-  tripLuggageId String?      @map("trip_luggage_id")
-  category      Category     @relation(fields: [categoryId], references: [id], onDelete: Cascade)
-  tripLuggage   TripLuggage? @relation(fields: [tripLuggageId], references: [id], onDelete: SetNull)
+  id         String   @id @default(uuid())
+  categoryId String   @map("category_id")
+  name       String
+  quantity   Int      @default(1)
+  isPacked   Boolean  @default(false) @map("is_packed")
+  isCustom   Boolean  @default(false) @map("is_custom")
+  order      Int      @default(0)
+  category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
 
   @@index([categoryId])
-  @@index([tripLuggageId])
   @@map("packing_items")
 }
 
@@ -114,36 +109,4 @@ model InventoryItem {
 
   @@index([categoryId])
   @@map("inventory_items")
-}
-
-model Luggage {
-  id           String        @id @default(uuid())
-  userId       String        @map("user_id")
-  name         String
-  type         String
-  capacity     Int?
-  createdAt    DateTime      @default(now()) @map("created_at")
-  updatedAt    DateTime      @updatedAt @map("updated_at")
-  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  tripLuggages TripLuggage[]
-
-  @@index([userId])
-  @@map("luggage")
-}
-
-model TripLuggage {
-  id           String        @id @default(uuid())
-  tripId       String        @map("trip_id")
-  luggageId    String        @map("luggage_id")
-  isActive     Boolean       @default(true) @map("is_active")
-  createdAt    DateTime      @default(now()) @map("created_at")
-  updatedAt    DateTime      @updatedAt @map("updated_at")
-  trip         Trip          @relation(fields: [tripId], references: [id], onDelete: Cascade)
-  luggage      Luggage       @relation(fields: [luggageId], references: [id], onDelete: Cascade)
-  packingItems PackingItem[]
-
-  @@unique([tripId, luggageId])
-  @@index([tripId])
-  @@index([luggageId])
-  @@map("trip_luggage")
 }


### PR DESCRIPTION
## Critical Production Fix

**Problem**: PR #20 merged schema changes that added `Luggage` and `TripLuggage` models without running database migrations. This broke production - users get 404 errors when creating trips because Prisma Client is out of sync with the actual database.

**Root Cause**: The schema was updated but `npx prisma migrate dev` was never run, so the new tables don't exist in the production database.

## This Hotfix

Reverts `prisma/schema.prisma` back to the working state (pre-luggage). This will:
- ✅ Fix trip creation immediately
- ✅ Restore all existing functionality
- ✅ Keep the luggage actions and types files for future use

## After Merging

You'll need to redeploy with:
```bash
npx prisma generate
```

This regenerates the Prisma Client to match the reverted schema.

## Next Steps for Luggage Feature

To properly implement luggage management:
1. Add schema changes in a new PR
2. Create migration: `npx prisma migrate dev --name add_luggage`
3. Test locally with migration
4. Deploy migration to production BEFORE deploying code
5. Then deploy the code changes