### PR TITLE
Fix: TypeScript error - tripLuggageId should accept null

### DIFF
--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -13,7 +13,7 @@ interface PackingItem {
   isPacked: boolean
   isCustom: boolean
   order: number
-  tripLuggageId?: string
+  tripLuggageId?: string | null
 }
 
 interface Category {
@@ -154,7 +154,7 @@ export default function PackingListSection({ trip }: { trip: Trip }) {
                   ? {
                       ...cat,
                       items: cat.items.map((item) =>
-                        item.id === itemId ? { ...item, tripLuggageId: tripLuggageId || undefined } : item
+                        item.id === itemId ? { ...item, tripLuggageId } : item
                       ),
                     }
                   : cat
@@ -171,7 +171,7 @@ export default function PackingListSection({ trip }: { trip: Trip }) {
     window.location.reload()
   }
 
-  function getLuggageIcon(tripLuggageId?: string) {
+  function getLuggageIcon(tripLuggageId?: string | null) {
     if (!tripLuggageId) return null
     const tl = tripLuggages.find((t) => t.id === tripLuggageId)
     if (!tl) return null


### PR DESCRIPTION
## Problem

Build fails with TypeScript error:
```
Type 'string | null' is not assignable to type 'string | undefined'.
Type 'null' is not assignable to type 'string | undefined'.
```

## Root Cause

Prisma returns `tripLuggageId` as `string | null` from the database, but the TypeScript interface defined it as `string | undefined`.

## Fix

Updated `PackingListSection.tsx` interface:
- Changed `tripLuggageId?: string` to `tripLuggageId?: string | null`
- Updated `getLuggageIcon` function signature to accept `string | null`
- Updated `handleAssignLuggage` to properly handle null values

## Changes

```typescript
// Before
interface PackingItem {
  tripLuggageId?: string
}

// After
interface PackingItem {
  tripLuggageId?: string | null
}
```

## Testing

- [x] Build passes without TypeScript errors
- [x] Luggage assignment dropdown works
- [x] "No bag" option correctly sets null
- [x] Icons display correctly

## Ready to Merge

This fixes the build failure and makes types match database schema.