### PR TITLE
Fix syntax error in day-plan.actions.ts

### DIFF
--- a/actions/day-plan.actions.ts
+++ b/actions/day-plan.actions.ts
@@ -10,13 +10,13 @@ async function getUserId(): Promise<string | null> {
   let authUser: any = null
 
   try {
-    const {  { user } } = await supabase.auth.getUser()
+    const { data: { user } } = await supabase.auth.getUser()
     authUser = user
   } catch {}
 
   if (!authUser) {
     try {
-      const {  { session } } = await supabase.auth.getSession()
+      const { data: { session } } = await supabase.auth.getSession()
       authUser = session?.user ?? null
     } catch {}
   }


### PR DESCRIPTION
Fixed invalid typescript destructuring syntax of Supabase `getUser()` and `getSession()` results inside `actions/day-plan.actions.ts`.

---
*PR created automatically by Jules for task [7549457361262498995](https://jules.google.com/task/7549457361262498995) started by @mvng*