### PR TITLE
🔒 Fix missing authorization check in addCustomItem

### DIFF
--- a/actions/packing.actions.ts
+++ b/actions/packing.actions.ts
@@ -48,6 +48,23 @@ export async function addCustomItem(
   tripId: string
 ) {
   try {
+    const user = await getAuthenticatedUser()
+    if (!user) return { error: 'Unauthorized' }
+
+    // Verify user owns the trip that this category belongs to
+    const category = await prisma.category.findFirst({
+      where: {
+        id: categoryId,
+        packingList: {
+          trip: {
+            userId: user.id
+          }
+        }
+      }
+    })
+
+    if (!category) return { error: 'Unauthorized' }
+
     const item = await prisma.packingItem.create({
       data: {
         categoryId,


### PR DESCRIPTION
🎯 **What:** The `addCustomItem` server action was missing an authorization check, allowing any user to add items to any category if they had the category ID.
⚠️ **Risk:** An attacker could exploit this Insecure Direct Object Reference (IDOR) to add unauthorized items to other users' packing lists, potentially disrupting their trips or filling their database with spam.
🛡️ **Solution:** Added a call to `getAuthenticatedUser()` and a Prisma `findFirst` query to verify that the category belongs to a packing list associated with a trip owned by the authenticated user before creating the item.

---
*PR created automatically by Jules for task [5838938853724961049](https://jules.google.com/task/5838938853724961049) started by @mvng*