### PR TITLE
🔍 Scout: Safe JSON-LD serialization for structured data

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,9 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-03-23 - [Robots.ts for Next.js App Router]
+**Learning:** To explicitly guide search engine crawlers away from authenticated or private application sections in Next.js App Router, implement an `app/robots.ts` file that returns a `MetadataRoute.Robots` object with specific `allow` and `disallow` rules, rather than relying solely on a static `robots.txt`.
+**Action:** Always verify if a `robots.ts` exists to manage crawl budget and privacy, and create one if missing.
+## 2024-03-23 - [JSON-LD XSS Prevention]
+**Learning:** When rendering JSON-LD structured data inside a `<script type="application/ld+json">` tag, using a plain `JSON.stringify` exposes the application to XSS if the data contains unescaped HTML tags (like `</script>`).
+**Action:** Always use a `serializeJsonLd` utility to safely escape `<` and `>` characters when injecting structured schema.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+import { serializeJsonLd } from '@/lib/utils'
 
 export default async function HomePage() {
   const supabase = await createClient()
@@ -26,7 +27,7 @@ export default async function HomePage() {
     <main className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
       />
       {/* Navigation */}
       <nav className="flex items-center justify-between px-6 py-4 max-w-7xl mx-auto">

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -99,3 +99,13 @@ export function getTripDuration(startDate: Date | string, endDate: Date | string
 export function generateId(): string {
   return crypto.randomUUID()
 }
+
+/**
+ * Serializes data to JSON-LD string while preventing XSS by escaping < and >
+ * Do not escape " or & as it breaks JSON syntax for search engine crawlers.
+ */
+export function serializeJsonLd(data: any): string {
+  return JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+}


### PR DESCRIPTION
💡 What:
Replaced the direct `JSON.stringify(jsonLd)` injection in `app/page.tsx` with a new `serializeJsonLd` utility function located in `lib/utils.ts`. This utility correctly escapes `<` and `>` characters to their Unicode equivalents (`\u003c` and `\u003e`).

🎯 Why:
Directly stringifying JSON-LD into a `<script type="application/ld+json">` tag creates a Cross-Site Scripting (XSS) vulnerability if any part of that payload contains a `</script>` tag (which closes the script block and allows subsequent arbitrary HTML/JS to execute). By escaping the structural HTML characters, the payload remains valid JSON for search engines but is entirely safe from browser interpretation as executable markup.

📊 Impact:
Prevents a class of XSS vulnerabilities related to dynamic Schema markup, ensuring technical SEO implementation is secure and robust for the landing page.

🔬 Verification:
Checked that the utility only escapes `<` and `>` (which neutralizes the XSS vector) without escaping structural JSON characters like `"` or `&`, which would break the crawler's ability to parse the schema correctly.

🔗 References:
https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data

---
*PR created automatically by Jules for task [10106502586640317244](https://jules.google.com/task/10106502586640317244) started by @mvng*