### PR TITLE
🎨 Palette: Add keyboard support to weather tooltip

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Add keyboard support to hover-based tooltips
+**Learning:** Found that custom tooltips using only `onMouseEnter` and `onMouseLeave` are completely inaccessible to keyboard users, as the content cannot be revealed without a pointer device.
+**Action:** Always ensure custom tooltip triggers include `tabIndex={0}`, `onFocus`, and `onBlur` handlers, along with proper `focus-visible` outline styling, so keyboard users can navigate to and read the tooltip content.

--- a/components/TripWeatherCardClient.tsx
+++ b/components/TripWeatherCardClient.tsx
@@ -13,9 +13,14 @@ export default function TripWeatherCardClient({ weather, children }: TripWeather
 
   return (
     <div
-      className="mt-3 pt-3 border-t border-gray-100 relative cursor-help"
+      className="mt-3 pt-3 border-t border-gray-100 relative cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md"
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
+      onFocus={() => setShowTooltip(true)}
+      onBlur={() => setShowTooltip(false)}
+      tabIndex={0}
+      role="region"
+      aria-label="Weather forecast details"
     >
       {children}
 


### PR DESCRIPTION
💡 What: Added keyboard focus support and visual focus styles to the weather summary card tooltip trigger. Also added role="region" and aria-label.
🎯 Why: The tooltip contains important context (especially the 14-day capped forecast warning) but was previously only revealed via `onMouseEnter`/`onMouseLeave`, making it completely inaccessible to users navigating by keyboard.
📸 Before/After: Before, tabbing over the element skipped it completely. Now, it receives focus with a clear blue ring, and the tooltip appears below it.
♿ Accessibility:
- Added `tabIndex={0}` to make the element focusable in the document flow.
- Added `onFocus` and `onBlur` handlers to reveal/hide the tooltip content.
- Added `focus-visible:ring-2 focus-visible:ring-blue-500` to ensure sighted keyboard users know they have focused the element.
- Added `role="region"` and `aria-label="Weather forecast details"` for screen reader context.

---
*PR created automatically by Jules for task [13105169197173870479](https://jules.google.com/task/13105169197173870479) started by @mvng*