### PR TITLE
🎨 Palette: [UX improvement] Enhance inventory action buttons accessibility

### DIFF
--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -89,7 +89,8 @@ export default function CategorySection({
                 onClick={() => onToggleFavorite(item)}
                 disabled={isPending}
                 title={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50"
+                aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`}
+                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded-sm"
               >
                 {item.isFavorite ? (
                   '⭐'
@@ -117,8 +118,9 @@ export default function CategorySection({
               <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
                 <button
                   onClick={() => onEditItem(item)}
-                  title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  title={`Edit ${item.name}`}
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 focus-visible:opacity-100"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -137,8 +139,9 @@ export default function CategorySection({
                 <button
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
-                  title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  title={`Delete ${item.name}`}
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1 focus-visible:opacity-100"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What:
Added descriptive `aria-label` attributes and keyboard focus indicators (`focus-visible`) to the favorite, edit, and delete action buttons in the inventory category list.

🎯 Why:
The action buttons (specifically edit and delete) were previously revealed only on hover and lacked `focus-visible` states, making them extremely difficult to discover and use for keyboard-only navigators. Furthermore, their generic `title` attributes ("Edit item", "Delete item") did not give screen reader users enough context when tabbing through multiple identical items in the list.

📸 Before/After:
Before:
- Tabbing through the list items did not visually reveal the edit/delete buttons clearly.
- Screen readers announced generic actions like "Edit item" or "Delete item".
- Favorite toggle lacked an `aria-label`.

After:
- Tabbing to the buttons visually reveals them with a clear blue/red focus ring.
- Screen readers announce the specific context, e.g., "Edit Passport" or "Delete Passport".
- Favorite toggle announces exactly what it does relative to the item context.

♿ Accessibility:
- Improves WCAG 2.1 Success Criterion 2.4.7 Focus Visible by adding `.focus-visible:ring-2` to interactive elements.
- Improves WCAG 2.1 Success Criterion 4.1.2 Name, Role, Value by providing unique, interpolated `aria-label`s for the action buttons instead of generic static labels.

---
*PR created automatically by Jules for task [7383178523908344149](https://jules.google.com/task/7383178523908344149) started by @mvng*