### PR TITLE
🎨 Palette: Make weather tooltips keyboard accessible

### DIFF
--- a/components/TripWeatherCardClient.tsx
+++ b/components/TripWeatherCardClient.tsx
@@ -13,9 +13,12 @@ export default function TripWeatherCardClient({ weather, children }: TripWeather
 
   return (
     <div
-      className="mt-3 pt-3 border-t border-gray-100 relative cursor-help"
+      className="mt-3 pt-3 border-t border-gray-100 relative cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded-lg"
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
+      onFocus={() => setShowTooltip(true)}
+      onBlur={() => setShowTooltip(false)}
+      tabIndex={0}
     >
       {children}
 

--- a/components/TripWeatherDetailClient.tsx
+++ b/components/TripWeatherDetailClient.tsx
@@ -18,11 +18,13 @@ export default function TripWeatherDetailClient({ weather, headerChildren, expan
       className="bg-gradient-to-br from-blue-50 via-sky-50 to-indigo-50 rounded-lg border border-blue-100 relative cursor-help shadow-sm overflow-hidden transition-all"
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
+      onFocus={() => setShowTooltip(true)}
+      onBlur={() => setShowTooltip(false)}
     >
       {/* Ultra-compact preview - no capped warning when collapsed */}
       <button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full px-3 py-2 flex items-center justify-between hover:bg-white hover:bg-opacity-30 transition-colors text-left gap-2"
+        className="w-full px-3 py-2 flex items-center justify-between hover:bg-white hover:bg-opacity-30 transition-colors text-left gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-lg"
         aria-expanded={isExpanded}
         aria-controls="weather-details"
       >


### PR DESCRIPTION
💡 What: Added keyboard focus handlers (`onFocus`, `onBlur`) and visible focus ring styles (`focus-visible`) to the trip weather display components (`TripWeatherCardClient` and `TripWeatherDetailClient`).
🎯 Why: The tooltips displaying the disclaimer that "weather forecasts are estimates" were previously only triggered by `onMouseEnter` and `onMouseLeave`, making this important information inaccessible to keyboard-only users who navigate via the Tab key.
📸 Before/After: Verified locally using Playwright script to simulate `Tab` navigation. Screenshots confirm tooltips successfully appear on focus and the container displays a clear blue focus ring outline.
♿ Accessibility:
- Added `tabIndex={0}` to the static `TripWeatherCardClient` div so it can receive focus.
- Bound `onFocus` and `onBlur` to trigger the tooltip state, matching the hover behavior.
- Added `focus-visible:ring-2 focus-visible:ring-blue-500` styles to ensure visual clarity when the elements are actively focused.

---
*PR created automatically by Jules for task [17613617649917813186](https://jules.google.com/task/17613617649917813186) started by @mvng*