### PR TITLE
🎨 Palette: Add context-interpolated ARIA labels to list item actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+
+## 2025-02-13 - Context-Interpolated ARIA Labels on List Items
+**Learning:** For interactive icon-only action buttons (like delete, add note, or pin) rendered dynamically inside lists, static `aria-label`s fail to provide distinguishability for screen reader users when multiple list items exist.
+**Action:** Always interpolate the context (e.g., `aria-label={"Remove " + item.name + " from packing list"}`) into the label, and ensure `focus-visible:ring-2` is present alongside `focus-within:opacity-100` so keyboard users can discover hidden hover elements and see clear focus states without showing rings on mouse clicks.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -748,23 +748,24 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
             <button
               onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
               title="Add/Edit Note"
-              className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
+              aria-label={"Add or edit note for " + item.name}
+              className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 flex items-center justify-center"
             ><MessageSquare className="w-3.5 h-3.5" /></button>
             <button
               onClick={() => handleTogglePackLast(item.id, item.categoryId, item.packingListId, item.packLast)}
               title={item.packLast ? 'Remove from departure checklist' : 'Add to departure checklist (pack last)'}
-              className={`text-xs p-1 rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center ${
+              className={`text-xs p-1 rounded-full border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 flex items-center justify-center ${
                 item.packLast
                   ? 'bg-amber-100 text-amber-700 border-amber-300'
                   : 'bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600'
               }`}
-              aria-label={item.packLast ? 'Remove from pack last' : 'Mark as pack last'}
+              aria-label={item.packLast ? "Remove " + item.name + " from departure checklist" : "Add " + item.name + " to departure checklist"}
             >
               <Sunrise className="w-3.5 h-3.5" />
             </button>
             <button
               onClick={() => handleDelete(item.id, item.categoryId, item.packingListId)}
-              className="text-red-400 hover:text-red-600 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded px-1"
+              className="text-red-400 hover:text-red-600 text-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 rounded px-1"
               aria-label={`Remove ${item.name} from packing list`}
             >
               <X className="w-4 h-4" />
@@ -1263,14 +1264,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                   <button
                                     onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
                                     title="Add/Edit Note"
-                                    className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
+                                    aria-label={"Add or edit note for " + item.name}
+                                    className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 flex items-center justify-center"
                                   ><MessageSquare className="w-3.5 h-3.5" /></button>
                                   <button
                                     onClick={() => handleTogglePackLast(item.id, category.id, list.id, item.packLast)}
                                     title="Add to departure checklist"
-                                    className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center"
+                                    aria-label={"Add " + item.name + " to departure checklist"}
+                                    className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 flex items-center justify-center"
                                   ><Sunrise className="w-3.5 h-3.5" /></button>
-                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
+                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded px-1 flex items-center" aria-label={`Remove ${item.name} from packing list`}><X className="w-4 h-4" /></button>
                                 </div>
                               )}
                             </li>


### PR DESCRIPTION
💡 **What:** Added context-interpolated `aria-label`s to the icon-only action buttons (Note, Pack Last, Delete) for packing list items, and upgraded their focus styles from `focus:ring-2` to `focus-visible:ring-2`.

🎯 **Why:** When multiple items are in a packing list, screen reader users cannot distinguish between identical "Delete" or "Add Note" buttons unless the label includes the item name (e.g., "Remove T-Shirt from packing list"). Additionally, mouse users were seeing persistent focus rings after clicking these buttons, which is solved by `focus-visible`.

📸 **Before/After:** No visible layout changes, but keyboard navigation now correctly shows blue/amber focus rings only when tabbing.

♿ **Accessibility:** Huge improvement for screen reader users navigating dynamic lists, and better focus management for keyboard users.

---
*PR created automatically by Jules for task [13648742331807327507](https://jules.google.com/task/13648742331807327507) started by @mvng*