### PR TITLE
🎨 Palette: Improve accessibility of task card actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-21 - Fix TaskCard Action Accessibility
+**Learning:** Hover-only action buttons hidden with `opacity-0` can become inaccessible to keyboard users because standard `focus` styling is not triggered if the container remains hidden. Also, purely icon-based actions require screen reader context.
+**Action:** Always combine `focus-within:opacity-100` on the hover container with `focus-visible:ring` and context-interpolated `aria-label`s (e.g., `aria-label={"Delete task: " + task.title}`) for list-item actions to ensure both visual keyboard visibility and precise screen-reader announcement.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -35,11 +35,12 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? `Mark ${task.title} as pending` : `Mark ${task.title} as done`}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
-          {isDone ? <CheckCircle className="w-5 h-5" /> : <Circle className="w-5 h-5" />}
+          {isDone ? <CheckCircle className="w-5 h-5" aria-hidden="true" /> : <Circle className="w-5 h-5" aria-hidden="true" />}
         </button>
 
         <div className="flex-1 min-w-0">
@@ -70,20 +71,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className={`flex items-center gap-1 transition-opacity focus-within:opacity-100 ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
-            title="Edit task"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
+            aria-label={`Edit task: ${task.title}`}
           >
-            <Edit2 className="w-4 h-4" />
+            <Edit2 className="w-4 h-4" aria-hidden="true" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
-            title="Delete task"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
+            aria-label={`Delete task: ${task.title}`}
           >
-            <Trash2 className="w-4 h-4" />
+            <Trash2 className="w-4 h-4" aria-hidden="true" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
💡 **What**: The UX enhancement added `aria-label`s to purely icon-based actions, hid decorative SVGs from screen readers, and enhanced keyboard support. Added `focus-within:opacity-100` so hover-only actions become visible when tabbed into. Added explicit `focus-visible` styling (`ring-2`) for visual feedback.

🎯 **Why**: Hover-only actions are inaccessible to keyboard users because the container remains `opacity-0` even if an interior element receives focus. Furthermore, icon-only buttons need screen reader context (e.g., "Edit task: Renew passport" instead of silence). This makes the task card fully inclusive.

📸 **Before/After**: Screen reader users now hear contextual descriptions for the action buttons instead of the title attribute or no description at all. Sighted keyboard users now see the action icons pop into view clearly outlined when tabbing through a list of tasks.

♿ **Accessibility**: 
- Replaced non-standard tooltips (`title`) on Edit/Delete with contextual `aria-label`s.
- Contextualized status toggle `aria-label`.
- Passed `aria-hidden="true"` to SVG elements to prevent repetitive announcements.
- Used `focus-within:opacity-100` on the hover container.
- Added explicit `focus-visible:ring` to interactive elements.

---
*PR created automatically by Jules for task [16551898478743195378](https://jules.google.com/task/16551898478743195378) started by @mvng*