### PR TITLE
🔍 Scout: [Add robots.ts for crawl scope control]

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Adding an explicit robots.ts configuration helps search engine crawlers understand
+// which areas of the application are public and which are private.
+// By disallowing routes like /dashboard, /settings, and /auth, we preserve crawl budget
+// for the public landing page and shared trips, while preventing crawlers from hitting
+// authentication redirects or indexing user-specific content.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/inventory/',
+        '/luggage/',
+        '/api/',
+        '/auth/',
+      ],
+    },
+  }
+}


### PR DESCRIPTION
💡 **What**: Added an explicit `app/robots.ts` file to guide search engine crawlers away from authenticated and private routes (`/dashboard`, `/settings`, `/inventory`, `/luggage`, `/api`, `/auth`).
🎯 **Why**: To preserve the crawl budget for public pages (like the landing page and public shared packing lists) and to prevent search engines from indexing user-specific content or hitting authentication redirects.
📊 **Impact**: Prevents index bloat with internal app pages and ensures Googlebot focuses its crawling resources on pages that drive traffic.
🔬 **Verification**: The code generates a `robots.txt` file at the root path, properly returning the `MetadataRoute.Robots` object conforming to Next.js APIs.
🔗 **References**: [Next.js robots.txt Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

---
*PR created automatically by Jules for task [9743803734195751510](https://jules.google.com/task/9743803734195751510) started by @mvng*