### PR TITLE
🎨 Palette: [UX improvement] Add accessible labels to PlanningBoardView elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2026-03-27 - Added missing aria-labels to PlanningBoardView buttons
+**Learning:** Several critical icon-only and interactive action buttons (like 'Add item', 'Cancel', 'Remove tag') in PlanningBoardView lacked descriptive `aria-label`s for screen reader users.
+**Action:** Ensure interactive buttons that contain only icons or generic text use context-interpolated `aria-label`s.

--- a/components/PlanningBoardView.tsx
+++ b/components/PlanningBoardView.tsx
@@ -271,6 +271,7 @@ function InlineTagCard({
         ) : (
           <button
             onClick={() => setEditingTime(true)}
+            aria-label={item.time ? `Edit time for ${tag?.label ?? item.name}` : `Add time for ${tag?.label ?? item.name}`}
             className="ml-2 text-[11px] opacity-60 hover:opacity-100 transition-opacity"
           >
             {item.time ? fmtTime(item.time) : <span className="italic">+ time</span>}
@@ -352,8 +353,8 @@ function AddItemForm({ onAdd, onOpenInventory }: {
 
   if (!open) return (
     <div className="flex items-center gap-3 pt-1">
-      <button onClick={() => setOpen(true)} className="text-xs text-blue-500 hover:text-blue-700 font-medium">+ Add item</button>
-      <button onClick={onOpenInventory} className="text-xs text-gray-400 hover:text-blue-500 transition-colors">+ Inventory</button>
+      <button onClick={() => setOpen(true)} aria-label="Add new day plan item" className="text-xs text-blue-500 hover:text-blue-700 font-medium">+ Add item</button>
+      <button onClick={onOpenInventory} aria-label="Add from inventory" className="text-xs text-gray-400 hover:text-blue-500 transition-colors">+ Inventory</button>
     </div>
   )
 
@@ -376,7 +377,7 @@ function AddItemForm({ onAdd, onOpenInventory }: {
         onChange={(e) => setNotes(e.target.value)} className={inputCls} />
       <div className="flex items-center gap-2">
         <button onClick={handleSubmit} className="bg-blue-500 text-white rounded-lg px-3 py-1 text-xs font-medium hover:bg-blue-600">Add</button>
-        <button onClick={() => setOpen(false)} className="text-xs text-gray-400 hover:text-gray-600">Cancel</button>
+        <button onClick={() => setOpen(false)} aria-label="Cancel adding item" className="text-xs text-gray-400 hover:text-gray-600">Cancel</button>
       </div>
     </div>
   )
@@ -497,7 +498,7 @@ function DayColumn({
               <span className="text-sm">{allDayTag.icon}</span>
               <span className={`text-[11px] font-semibold ${headerText} opacity-90`}>{allDayTag.label}</span>
               <span className={`text-[10px] ml-0.5 opacity-50 ${headerText}`}>— all day</span>
-              <button onClick={() => saveLabel('')} className={`ml-auto text-[11px] opacity-60 hover:opacity-100 ${headerText} focus:outline-none leading-none`}>✕</button>
+              <button onClick={() => saveLabel('')} aria-label="Remove all day tag" className={`ml-auto text-[11px] opacity-60 hover:opacity-100 ${headerText} focus:outline-none leading-none`}>✕</button>
             </div>
           ) : editingLabel ? (
             <input autoFocus type="text" value={labelInput}
@@ -507,7 +508,7 @@ function DayColumn({
               className="mt-1 text-[11px] w-full bg-white border border-gray-200 rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           ) : (
-            <button onClick={() => setEditingLabel(true)} className="mt-0.5 focus:outline-none rounded w-full text-left">
+            <button onClick={() => setEditingLabel(true)} aria-label={dayPlan?.label ? "Edit day label" : "Add day label"} className="mt-0.5 focus:outline-none rounded w-full text-left">
               {dayPlan?.label
                 ? <span className="text-[11px] text-gray-500 font-medium">{dayPlan.label}</span>
                 : <span className={`text-[11px] italic ${dropping ? 'text-blue-400' : 'text-gray-300'}`}>
@@ -544,7 +545,7 @@ function DayColumn({
               <div className="mb-1.5">
                 {toast
                   ? <p className="text-[11px] text-indigo-500">{toast}</p>
-                  : <button onClick={handleSaveToInventory} className="text-[11px] text-gray-400 hover:text-indigo-600 font-medium transition-colors">↓ Save to inventory</button>
+                  : <button onClick={handleSaveToInventory} aria-label="Save day plan items to inventory" className="text-[11px] text-gray-400 hover:text-indigo-600 font-medium transition-colors">↓ Save to inventory</button>
                 }
               </div>
             )}


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to various icon-only and interactive buttons within `components/PlanningBoardView.tsx`.
🎯 Why: To improve keyboard navigation and screen reader accessibility, turning previously opaque actions (like a bare "✕" or a "+ time" button) into fully descriptive labels (e.g., "Remove all day tag" or "Add time for Task").
📸 Before/After: No visual changes; purely structural HTML/ARIA additions.
♿ Accessibility: Ensures that users navigating via assistive technology can properly understand the purpose of each button in the Day Plan planning view.

---
*PR created automatically by Jules for task [17888273143928166901](https://jules.google.com/task/17888273143928166901) started by @mvng*