### PR TITLE
🔍 Scout: Add robust robots.txt via Next.js Metadata API

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-03-27 - [Next.js App Router robots.txt via Metadata API]
+**Learning:** Next.js App Router supports native programmatic robots.txt generation via a special `app/robots.ts` file exporting a `MetadataRoute.Robots` return object. Using this correctly guides search engine crawlers away from authenticated or private application sections (`/dashboard/`, `/api/`, etc), preserving crawl budget and improving overall technical SEO.
+**Action:** When working on technical SEO in Next.js applications, use `app/robots.ts` instead of static `public/robots.txt` for easier integration with framework capabilities (like dynamic environment switching or programmatic sitemap referencing).

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/'], // All public paths are allowed by default
+      disallow: [
+        // SCOUT SEO RATIONALE:
+        // Disallow crawling of private authenticated routes and APIs.
+        // This preserves crawl budget and ensures search engines focus
+        // entirely on public-facing pages (home, login, shared claim pages).
+        '/dashboard/',
+        '/settings/',
+        '/inventory/',
+        '/luggage/',
+        '/trip/',
+        '/api/'
+      ],
+    },
+    // If you add a sitemap later, include the URL here:
+    // sitemap: 'https://packwise-indol.vercel.app/sitemap.xml',
+  }
+}


### PR DESCRIPTION
💡 **What:** Added `app/robots.ts` using the Next.js Metadata API to generate a programmatic `robots.txt` file.

🎯 **Why:** The site was previously missing a `robots.txt` file, meaning search engine crawlers could attempt to index authenticated or API routes (like `/dashboard/` or `/api/`). By explicitly disallowing these sections, we preserve crawl budget and direct search engine efforts toward public-facing, indexable content.

📊 **Impact:** 
* Prevents search engine indexing of private application states and data.
* Improves crawl efficiency by stopping bots from wasting time on 401/403 responses.
* Ensures search presence is focused solely on marketing and shared pages.

🔬 **Verification:** 
* Confirmed `MetadataRoute.Robots` structure matches Next.js specifications.
* Unit tests passing and build checks clear.
* Checked that public routes (e.g. `/claim/`) remain open to crawlers while sensitive paths are blocked.

🔗 **References:** 
* [Next.js robots.ts Documentation](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)
* [Google Search Central: Introduction to robots.txt](https://developers.google.com/search/docs/crawling-indexing/robots/intro)

---
*PR created automatically by Jules for task [15649538728779716639](https://jules.google.com/task/15649538728779716639) started by @mvng*