### PR TITLE
🎨 Palette: Improve keyboard accessibility on Dashboard trip cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve keyboard accessibility for hover-revealed action buttons
+**Learning:** Found that secondary action buttons (like Edit/Delete on trip cards) are often hidden via `opacity-0` and only shown on mouse hover (`group-hover:opacity-100`). This makes them completely invisible to keyboard users navigating via Tab.
+**Action:** When hiding buttons via `opacity-0` that reveal on hover, always ensure the parent container also includes `focus-within:opacity-100` so they appear during keyboard navigation, and add explicit `focus-visible` outline utilities to the buttons themselves.

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -157,10 +157,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 flex gap-1 transition-opacity">
+      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-1 transition-opacity">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -168,7 +168,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
@@ -200,10 +200,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
+      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -211,7 +211,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}


### PR DESCRIPTION
💡 **What**: Added `focus-within:opacity-100` to the action button containers on the Dashboard trip cards and added `focus-visible:ring-2` to the buttons themselves.
🎯 **Why**: The secondary actions (Edit/Delete) on the trip cards were previously only visible on mouse hover (`group-hover:opacity-100`), making them completely invisible and undiscoverable for users navigating via the keyboard (Tab).
📸 **Before/After**: Keyboard users tabbing through the dashboard can now visibly see the action buttons appear with a distinct blue/red focus ring instead of navigating through invisible elements.
♿ **Accessibility**: Significant improvement for keyboard navigability and WCAG 2.1 Focus Visible criteria (2.4.7).

---
*PR created automatically by Jules for task [9493271148994463675](https://jules.google.com/task/9493271148994463675) started by @mvng*