### PR TITLE
🎨 Palette: Improve accessibility of packing list actions

### DIFF
--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -748,23 +748,24 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
             <button
               onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
               title="Add/Edit Note"
-              className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
+              aria-label={`Add or edit note for ${item.name}`}
+              className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 flex items-center justify-center"
             ><MessageSquare className="w-3.5 h-3.5" /></button>
             <button
               onClick={() => handleTogglePackLast(item.id, item.categoryId, item.packingListId, item.packLast)}
               title={item.packLast ? 'Remove from departure checklist' : 'Add to departure checklist (pack last)'}
-              className={`text-xs p-1 rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center ${
+              className={`text-xs p-1 rounded-full border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 flex items-center justify-center ${
                 item.packLast
                   ? 'bg-amber-100 text-amber-700 border-amber-300'
                   : 'bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600'
               }`}
-              aria-label={item.packLast ? 'Remove from pack last' : 'Mark as pack last'}
+              aria-label={item.packLast ? `Remove ${item.name} from pack last` : `Mark ${item.name} as pack last`}
             >
               <Sunrise className="w-3.5 h-3.5" />
             </button>
             <button
               onClick={() => handleDelete(item.id, item.categoryId, item.packingListId)}
-              className="text-red-400 hover:text-red-600 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded px-1"
+              className="text-red-400 hover:text-red-600 text-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 rounded px-1"
               aria-label={`Remove ${item.name} from packing list`}
             >
               <X className="w-4 h-4" />
@@ -865,7 +866,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         {itemCount > 0 && <span className="text-xs text-gray-500">({itemCount})</span>}
                         <button
                           onClick={() => handleRemoveLuggage(tl.id, tl.luggageId)}
-                          className="ml-1 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"
+                          className="ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-gray-400 hover:text-red-500 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded px-1 flex items-center"
                           aria-label={`Remove ${tl.luggage.name}`}
                         ><X className="w-3.5 h-3.5" /></button>
                       </div>
@@ -1263,14 +1264,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                   <button
                                     onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
                                     title="Add/Edit Note"
-                                    className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
+                                    aria-label={`Add or edit note for ${item.name}`}
+                                    className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 flex items-center justify-center"
                                   ><MessageSquare className="w-3.5 h-3.5" /></button>
                                   <button
                                     onClick={() => handleTogglePackLast(item.id, category.id, list.id, item.packLast)}
                                     title="Add to departure checklist"
-                                    className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center"
+                                    aria-label={`Add ${item.name} to departure checklist`}
+                                    className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 flex items-center justify-center"
                                   ><Sunrise className="w-3.5 h-3.5" /></button>
-                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
+                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} aria-label={`Remove ${item.name} from packing list`} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
                                 </div>
                               )}
                             </li>


### PR DESCRIPTION
💡 What: Added specific, descriptive `aria-label`s to the icon-only buttons on packing list items (like "Add/Edit Note", "Pack Last", and "Delete"). Additionally, ensured the "Remove Luggage" button (which is typically revealed on hover) properly appears when receiving keyboard focus.

🎯 Why: To make the packing list interface fully usable and intuitive for keyboard and screen-reader users. Without specific labels (e.g. `aria-label="Delete item"` vs `aria-label="Remove T-Shirt from packing list"`), screen readers read out identical "Delete" buttons repeatedly without context. Without `focus-visible:opacity-100`, keyboard users tabbing through the bags section could focus an invisible button.

📸 Before/After: Visuals verified via Playwright screenshot; focus states work properly, mouse interaction maintains clean UI without permanent rings.

♿ Accessibility: Contextual `aria-label`s on generic actions; updated hover-only opacity states to be focus-visible inclusive.

---
*PR created automatically by Jules for task [16226479483749382321](https://jules.google.com/task/16226479483749382321) started by @mvng*