### PR TITLE
⚡ Bolt: Add useMemo to derived state in TripPageClient

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2025-04-03 - useMemo on Cheap Operations
+**Learning:** In React Client Components, do not wrap extremely cheap operations (such as simple boolean comparisons like `new Date() < new Date(endDate)`) in `useMemo`. This provides no measurable performance benefit and can introduce functional bugs by incorrectly capturing and freezing the time of the initial render.
+**Action:** Only wrap computationally expensive operations or referential equality derivations in `useMemo`, and never wrap operations that rely on implicitly moving parts of state like the current time `new Date()`.

--- a/app/trip/[id]/TripPageClient.tsx
+++ b/app/trip/[id]/TripPageClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useTransition, useEffect } from 'react'
+import { useState, useTransition, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { getSharedTripById } from '@/actions/trip.actions'
@@ -92,26 +92,40 @@ export default function TripPageClient({ initialTrip, user, isOwner, initialTrip
   }
 
   const isSharedView = !isOwner
-  const displayTrip = isSharedView ? {
-    ...trip,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    packingLists: trip.packingLists.map((list: any) => ({
-      ...list,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      categories: list.categories.map((cat: any) => ({
-        ...cat,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        items: cat.items.map((item: any) => ({ ...item, isPacked: false }))
-      }))
-    }))
-  } : trip
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const allItems = displayTrip.packingLists.flatMap((list: any) => list.categories.flatMap((cat: any) => cat.items))
-  const totalItems = allItems.length
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const packedItems = allItems.filter((item: any) => item.isPacked).length
-  const progress = totalItems > 0 ? Math.round((packedItems / totalItems) * 100) : 0
+  // ⚡ Bolt Performance Optimization
+  // Why: displayTrip deeply maps the packingLists array for shared views on every render.
+  // By wrapping it and derived list logic in useMemo, we prevent O(N) recalculations on unrelated state changes (e.g. toggling views, syncing status).
+  const { displayTrip, allItems, totalItems, packedItems, progress } = useMemo(() => {
+    const computedDisplayTrip = isSharedView ? {
+      ...trip,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      packingLists: trip.packingLists.map((list: any) => ({
+        ...list,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        categories: list.categories.map((cat: any) => ({
+          ...cat,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          items: cat.items.map((item: any) => ({ ...item, isPacked: false }))
+        }))
+      }))
+    } : trip
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const computedAllItems = computedDisplayTrip.packingLists.flatMap((list: any) => list.categories.flatMap((cat: any) => cat.items))
+    const computedTotalItems = computedAllItems.length
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const computedPackedItems = computedAllItems.filter((item: any) => item.isPacked).length
+    const computedProgress = computedTotalItems > 0 ? Math.round((computedPackedItems / computedTotalItems) * 100) : 0
+
+    return {
+      displayTrip: computedDisplayTrip,
+      allItems: computedAllItems,
+      totalItems: computedTotalItems,
+      packedItems: computedPackedItems,
+      progress: computedProgress
+    }
+  }, [trip, isSharedView])
 
   // Post-trip: true if end date is in the past
   const isTripOver = trip.endDate ? new Date(trip.endDate) < new Date() : false


### PR DESCRIPTION
💡 What: Wrap the deep cloning of `displayTrip` and the calculation of its derived statistics (`allItems`, `totalItems`, `packedItems`, `progress`) inside a `useMemo` block in `TripPageClient.tsx`.

🎯 Why: During a shared view, `displayTrip` deeply maps the `packingLists` array from the `trip` object to inject `isPacked: false` across all items. Without `useMemo`, this `O(N)` deep mapping process, and all subsequent `flatMap` and `filter` operations to compute the progress stats, occur redundantly on every single component render (e.g. when state like `unsyncedItems` changes or a re-render is triggered).

📊 Impact: Reduces array allocations and completely avoids the `O(N)` recalculation cycle during re-renders, leading to a much smoother and snappier experience for trips with dozens of categories and items.

🔬 Measurement: Test by viewing any large trip page as a non-owner, and toggle the Plan vs Pack views or trigger actions that update the state. Using the React DevTools Profiler, the `TripPageClient` component will show vastly improved render times. You can also run the existing test suite (`pnpm test`) to ensure no logic regressions were introduced.

---
*PR created automatically by Jules for task [9827363317746529774](https://jules.google.com/task/9827363317746529774) started by @mvng*