### PR TITLE
🔧 Fix: Surface trip notes in trip view with auto-save

### DIFF
--- a/app/trip/[id]/TripPageClient.tsx
+++ b/app/trip/[id]/TripPageClient.tsx
@@ -11,6 +11,7 @@ import TripCountdown from '@/components/TripCountdown'
 import EditTripModal from '@/components/EditTripModal'
 import PackingRating from '@/components/PackingRating'
 import TripMembersSection from '@/components/TripMembersSection'
+import TripNotes from '@/components/TripNotes'
 import { formatDate } from '@/lib/utils'
 import dynamic from 'next/dynamic'
 import { Calendar, Check, RefreshCw } from 'lucide-react'
@@ -268,6 +269,12 @@ export default function TripPageClient({ initialTrip, user, isOwner, initialTrip
           <div className="mt-5 pt-5 border-t border-gray-100">
             <TripMembersSection tripId={trip.id} members={trip.members || []} isOwner={isOwner} />
           </div>
+
+          <TripNotes
+            tripId={trip.id}
+            initialNotes={trip.notes}
+            readOnly={isSharedView}
+          />
         </div>
 
         {/* View toggle */}

--- a/components/TripNotes.tsx
+++ b/components/TripNotes.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { updateTrip } from '@/actions/trip.actions'
+import { Check } from 'lucide-react'
+
+interface TripNotesProps {
+  tripId: string
+  initialNotes: string | null
+  readOnly: boolean
+}
+
+export default function TripNotes({ tripId, initialNotes, readOnly }: TripNotesProps) {
+  const [notes, setNotes] = useState(initialNotes || '')
+  const [isSaving, setIsSaving] = useState(false)
+  const [showSaved, setShowSaved] = useState(false)
+
+  // Sync state if initialNotes changes from a parent re-render
+  useEffect(() => {
+    setNotes(initialNotes || '')
+  }, [initialNotes])
+
+  const handleBlur = async () => {
+    const trimmedNotes = notes.trim()
+    const previousNotes = initialNotes || ''
+
+    // Only save if it actually changed
+    if (trimmedNotes === previousNotes) return
+
+    setIsSaving(true)
+    const result = await updateTrip(tripId, { notes: trimmedNotes || null })
+    setIsSaving(false)
+
+    if (result?.success) {
+      setShowSaved(true)
+      setTimeout(() => setShowSaved(false), 2000)
+    }
+  }
+
+  if (readOnly) {
+    if (!notes) return null
+
+    return (
+      <div className="mt-5 pt-5 border-t border-gray-100">
+        <h3 className="text-sm font-semibold text-gray-900 mb-2">Trip Notes</h3>
+        <div className="bg-gray-50 rounded-xl p-4 text-sm text-gray-700 whitespace-pre-wrap">
+          {notes}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-5 pt-5 border-t border-gray-100">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-semibold text-gray-900">Trip Notes</h3>
+        <div className="flex items-center gap-3">
+          {isSaving && <span className="text-xs text-gray-400">Saving...</span>}
+          {showSaved && (
+            <span className="text-xs text-green-600 flex items-center gap-1">
+              <Check className="w-3 h-3" /> Saved
+            </span>
+          )}
+          <span className={`text-xs ${notes.length > 450 ? 'text-amber-500' : 'text-gray-400'}`}>
+            {notes.length} / 500
+          </span>
+        </div>
+      </div>
+      <textarea
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+        onBlur={handleBlur}
+        maxLength={500}
+        rows={3}
+        placeholder="Any additional details or free-form notes for this trip..."
+        className="w-full px-4 py-3 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none text-sm text-gray-800 transition-shadow"
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
🐛 **Issue:** Closes #48
🔍 **Root Cause:** The `Trip.notes` field existed in the schema and the edit modal, but was not surfaced as a dedicated free-form area in the trip detail view as requested in the enhancement schedule.
🛠️ **Fix:** Created a `TripNotes` component and integrated it into the `TripPageClient` (below the members section). The component features an auto-save text area on blur, a 500-character limit with a counter, a visual "Saved" confirmation indicator, and supports a read-only mode for shared trip views.
✅ **Verification:** 
- Verified using Playwright E2E visual test script demonstrating text input, character count updates, blur to save, and the "Saved" indicator rendering properly.
- Tested `readOnly` fallback logic to display static text rather than a disabled input field.
⚠️ **Notes:** Integrates nicely into the existing `updateTrip` server action. Auto-save fires strictly on `onBlur` to match the specification without introducing unnecessary debounce polling logic on every keystroke.

---
*PR created automatically by Jules for task [3289274504063221802](https://jules.google.com/task/3289274504063221802) started by @mvng*