### PR TITLE
🔍 Scout: [SEO improvement] Add robots.ts and sitemap.ts for crawler guidance

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,9 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2025-02-23 - [Next.js robots.ts Implementation]
+**Learning:** To explicitly guide search engine crawlers away from authenticated or private application sections in Next.js App Router, implement an `app/robots.ts` file that returns a `MetadataRoute.Robots` object with specific `allow` and `disallow` rules, rather than relying solely on a static `robots.txt`.
+**Action:** Always prefer native Next.js API configuration for `robots.ts` over static `.txt` files in App Router setups to easily integrate dynamic logic later if needed.
+## 2025-02-23 - [Next.js sitemap.ts Implementation]
+**Learning:** To generate a sitemap in Next.js App Router, implement an `app/sitemap.ts` file returning a `MetadataRoute.Sitemap` array. Only include public static routes (e.g., `/`, `/login`) and omit private or unlisted dynamic routes (e.g., `/claim/[token]`).
+**Action:** Implement `sitemap.ts` for all public-facing applications to assist crawlers, ensuring that private or authenticated paths are expressly omitted to protect crawl budget and privacy.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Explicitly guiding search engine crawlers away from authenticated or private
+// application sections (e.g. /dashboard, /settings, /inventory) prevents them
+// from wasting crawl budget on inaccessible pages, and ensures only public-facing
+// routes (like the homepage and shared claim pages) are indexed.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/claim/'],
+      disallow: [
+        '/dashboard/',
+        '/inventory/',
+        '/luggage/',
+        '/settings/',
+        '/trip/',
+        '/api/',
+      ],
+    },
+    sitemap: 'https://packwise-indol.vercel.app/sitemap.xml',
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Generating a sitemap ensures that search engine crawlers can efficiently
+// discover all public-facing routes, improving the indexability of the application.
+// We only include public static routes like the home and login pages. Dynamic
+// routes like /claim/[token] are omitted to keep them relatively private until
+// they are explicitly shared via links.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** 
Implemented Next.js `app/robots.ts` and `app/sitemap.ts` to natively configure search engine crawler guidance.

🎯 **Why:** 
Without explicit instructions, crawlers may waste valuable crawl budget attempting to access authenticated or private sections of the app (like Settings or Dashboard), which ultimately result in unindexable pages or redirects. A defined sitemap explicitly highlights the core public-facing pages that should be indexed and ranked.

📊 **Impact:** 
Improves indexability of public routes while actively preventing search engines from wasting resources or indexing restricted application paths.

🔬 **Verification:** 
Verified functionality by building and observing Next.js's native generation of `robots.txt` and `sitemap.xml`. Ensured no regressions by running tests and linting.

🔗 **References:** 
- Next.js Metadata Files: [Robots](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)
- Next.js Metadata Files: [Sitemap](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [7258638708794561941](https://jules.google.com/task/7258638708794561941) started by @mvng*