### PR TITLE
🔍 Scout: [Add explicit sitemap and robots.txt generation]

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-03-29 - [Next.js App Router Robots.txt]
+**Learning:** To explicitly guide search engine crawlers away from authenticated or private application sections in Next.js App Router, implement an `app/robots.ts` file that returns a `MetadataRoute.Robots` object with specific `allow` and `disallow` rules, rather than relying solely on a static `robots.txt`.
+**Action:** Always consider explicit route-level exclusion through `robots.ts` for dynamic Next.js applications with large authenticated surface areas.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = 'https://packwise-indol.vercel.app'
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: [
+        '/dashboard',
+        '/settings',
+        '/trip/',
+        '/inventory',
+        '/luggage',
+        '/api/',
+        '/auth/',
+        '/claim/',
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:**
Implemented Next.js `MetadataRoute` native generation for `sitemap.xml` and `robots.txt` by adding `app/sitemap.ts` and `app/robots.ts`. The robots file explicitly allows public routes (`/` and `/login`) while disallowing private, authenticated, or dynamic utility paths.

🎯 **Why:**
Previously, the site lacked instructions for search engine crawlers, meaning they could waste crawl budget attempting to index private routes (e.g. `/dashboard`, `/settings`, `/trip/`) which would simply redirect or fail, while potentially missing the primary indexable pages. This adds clarity and control over search visibility.

📊 **Impact:**
Improves crawl efficiency by directing bots to the homepage and login page while preventing indexing of private user data or functional endpoints. 

🔬 **Verification:**
Confirmed generation structure matches Next.js specifications. Can be verified in production by inspecting the `/sitemap.xml` and `/robots.txt` paths. Tested via `pnpm lint` and local tests.

🔗 **References:**
- [Next.js Sitemap Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)
- [Next.js Robots Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

---
*PR created automatically by Jules for task [17650152774837012082](https://jules.google.com/task/17650152774837012082) started by @mvng*