### PR TITLE
🎨 Palette: Improve TaskCard keyboard accessibility and hover states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2026-03-29 - Keyboard Accessible Hover Actions
+**Learning:** Using React `onMouseEnter`/`onMouseLeave` state to reveal action buttons completely hides them from keyboard-only users who tab through the interface.
+**Action:** Always use Tailwind CSS group hover and focus-within (`opacity-0 group-hover:opacity-100 focus-within:opacity-100`) to reveal action buttons, ensuring they become visible when focused via keyboard.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -21,25 +21,23 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? `Mark task ${task.title} as incomplete` : `Mark task ${task.title} as complete`}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
-          {isDone ? <CheckCircle className="w-5 h-5" /> : <Circle className="w-5 h-5" />}
+          {isDone ? <CheckCircle className="w-5 h-5" aria-hidden="true" /> : <Circle className="w-5 h-5" aria-hidden="true" />}
         </button>
 
         <div className="flex-1 min-w-0">
@@ -70,20 +68,22 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            aria-label={`Edit task ${task.title}`}
             title="Edit task"
           >
-            <Edit2 className="w-4 h-4" />
+            <Edit2 className="w-4 h-4" aria-hidden="true" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+            aria-label={`Delete task ${task.title}`}
             title="Delete task"
           >
-            <Trash2 className="w-4 h-4" />
+            <Trash2 className="w-4 h-4" aria-hidden="true" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
💡 **What:** Improved the keyboard accessibility and screen reader support for the `TaskCard` component used in the Trip Planning Assistant. Replaced the Javascript-based `onMouseEnter` state with native Tailwind CSS `group-hover` and `focus-within` selectors.

🎯 **Why:** Previously, the edit and delete action buttons were completely invisible to users navigating with a keyboard because they were hidden by React state that only listened for mouse events. The buttons also lacked descriptive text for screen readers (e.g., they just had tooltips like "Delete task" rather than "Delete task [Title]").

📸 **Before/After:** See the generated Playwright verification screenshot which demonstrates the newly visible action container and blue focus ring when tabbing via keyboard.

♿ **Accessibility:**
* **Keyboard Navigation:** Action buttons now become visible when focused using the `Tab` key (via `focus-within`).
* **Visual Focus Indicators:** Added standard `focus-visible:ring-2` to all interactive icon buttons so it's clear what is focused.
* **Screen Reader Context:** Replaced generic tooltips with specific `aria-label`s (e.g., `aria-label="Delete task Book Flight"`) and added `aria-hidden="true"` to the decorative SVG icons to reduce noise.

---
*PR created automatically by Jules for task [15536964591497697940](https://jules.google.com/task/15536964591497697940) started by @mvng*