### PR TITLE
🔍 Scout: Add robots.txt and sitemap.xml to improve crawlability

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,22 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = 'https://packwise-indol.vercel.app'
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: [
+        '/dashboard/',
+        '/inventory/',
+        '/settings/',
+        '/trip/',
+        '/luggage/',
+        '/claim/',
+        '/api/',
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,21 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://packwise-indol.vercel.app'
+
+  // Omit private or dynamic routes like /dashboard, /settings, /inventory, /trip, /luggage, /claim
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** 
Added native Next.js `app/robots.ts` and `app/sitemap.ts` to generate dynamic `robots.txt` and `sitemap.xml` files.

🎯 **Why:** 
Previously, search engines were not explicitly guided on what pages were public (indexable) and which were private (authenticated). The new `robots.txt` explicitly allows the `/` and `/login` routes, while adding a `disallow` list for private routes (like `/dashboard`, `/settings`, `/trip/`, etc.) to prevent crawl waste. The `sitemap.xml` feeds directly into search engines' indexing queues for valid public entrypoints.

📊 **Impact:** 
- Better crawl efficiency by preventing Googlebot from attempting to crawl deeply into unauthenticated areas.
- Clearer site structure signaling to search engines, improving indexation of key landing pages.

🔬 **Verification:** 
- `pnpm lint` and `pnpm test` completed successfully.
- Code reviewed locally.

🔗 **References:** 
- [Next.js App Router Metadata Files](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

---
*PR created automatically by Jules for task [15941756210963744773](https://jules.google.com/task/15941756210963744773) started by @mvng*