### PR TITLE
🎨 Palette: Enhance accessibility of inventory action buttons

### DIFF
--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -118,7 +118,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -126,6 +127,7 @@ export default function CategorySection({
                     viewBox="0 0 24 24"
                     stroke="currentColor"
                     strokeWidth={2}
+                    aria-hidden="true"
                   >
                     <path
                       strokeLinecap="round"
@@ -138,7 +140,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -146,6 +149,7 @@ export default function CategorySection({
                     viewBox="0 0 24 24"
                     stroke="currentColor"
                     strokeWidth={2}
+                    aria-hidden="true"
                   >
                     <path
                       strokeLinecap="round"


### PR DESCRIPTION
💡 What: 
Added descriptive `aria-label` attributes to the icon-only "Edit" and "Delete" buttons within the Inventory `CategorySection.tsx`.
Hidden the nested decorative SVGs from screen readers via `aria-hidden="true"`.
Added clear keyboard focus indicators (`focus-visible:ring-2`, `focus-visible:outline-none`, etc.)

🎯 Why: 
The action buttons in the inventory category section were completely identical to screen readers without context ("button", "button"), and were difficult for keyboard-only users to navigate securely since the hover state relies on mouse interaction. This makes the actions explicitly clear and easy to focus.

📸 Before/After:
Before: `group-hover:opacity-100` with no explicit focus rings or labels.
After: Focus rings now appear around the buttons when tab-navigating through the items, and screen readers read "Edit Passport" instead of generic "button".

♿ Accessibility: 
- `aria-label` interpolation added to clarify the target of the action.
- Decorative SVGs marked with `aria-hidden="true"`.
- Enhanced focus management via `focus-visible` utility classes.

---
*PR created automatically by Jules for task [11143306179814494645](https://jules.google.com/task/11143306179814494645) started by @mvng*