### PR TITLE
🎨 Palette: Improve accessibility in TripMembersSection

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve TripMembersSection accessibility
+**Learning:** Found that multiple interactive elements representing user actions (remove, add, confirm, cancel) inside `TripMembersSection` were relying solely on standard DOM `title` attributes for tooltips without specifying `aria-label` attributes. Additionally, none had specific `focus-visible` styling making keyboard navigation practically invisible.
+**Action:** When adding or editing small inline form buttons (like Add/Remove pills or Confirm/Cancel icon buttons), always provide clear `aria-label`s and `focus-visible:ring-2` styles using Tailwind to ensure the interface is fully usable with screen readers and keyboards. Use `aria-hidden="true"` on nested decorative icons inside those buttons to avoid redundant screen reader noise.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,13 +58,14 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden" aria-hidden="true">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block" aria-hidden="true" />}
             </button>
             {/* Tooltip */}
             <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
@@ -84,10 +85,11 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
             title="Add member"
+            aria-label="Add member"
           >
-            <Plus className="w-3.5 h-3.5" />
+            <Plus className="w-3.5 h-3.5" aria-hidden="true" />
           </button>
         )}
       </div>
@@ -110,17 +112,19 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
             title="Confirm"
+            aria-label="Confirm adding member"
           >
-            <Check className="w-3.5 h-3.5" />
+            <Check className="w-3.5 h-3.5" aria-hidden="true" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 focus-visible:ring-offset-1"
             title="Cancel"
+            aria-label="Cancel adding member"
           >
-            <X className="w-3.5 h-3.5" />
+            <X className="w-3.5 h-3.5" aria-hidden="true" />
           </button>
         </div>
       )}


### PR DESCRIPTION
💡 What:
Added appropriate `aria-label`s and `focus-visible` styles to the interactive elements (buttons) in `components/TripMembersSection.tsx`.

🎯 Why:
The buttons in the `TripMembersSection` (Remove member, Add member, Confirm, and Cancel) lacked appropriate `aria-label`s, which made them inaccessible to screen readers. Furthermore, the buttons had no keyboard focus states, making the interface very hard to navigate using a keyboard alone. These changes ensure the component is accessible for keyboard and screen reader users.

📸 Before/After:
The UI visually remains identical on mouse hover. Keyboard users will now see standard blue and gray rings around the focused elements as they tab through the interface.

♿ Accessibility:
- Added context-aware `aria-label`s (e.g., "Remove Alice") to member pills when the current user is the owner.
- Added explicit `aria-label`s to the "Add member", "Confirm", and "Cancel" buttons.
- Added `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-offset-1` classes (or equivalent colored rings) to all interactive elements.
- Added `aria-hidden="true"` to decorative nested SVG icons inside these buttons to prevent redundant screen reader announcements.

---
*PR created automatically by Jules for task [7158863272044755002](https://jules.google.com/task/7158863272044755002) started by @mvng*