### PR TITLE
🔎 Scout: Add robots.ts and sitemap.xml for crawler control

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Adding a dynamic robots.txt file explicitly guides search engine crawlers away from
+// private, authenticated areas of the application (e.g., /dashboard, /settings, /trip).
+// This prevents crawlers from hitting redirect loops or error pages, thereby optimizing
+// crawl budget and focusing search indexing exclusively on public-facing landing pages
+// like the home page (/) and the /login page.
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: [
+        '/dashboard',
+        '/settings',
+        '/trip',
+        '/inventory',
+        '/luggage',
+        '/claim',
+        '/api/',
+        '/_next/',
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Generating a sitemap is critical for signaling high-value, indexable pages to search engines.
+// This sitemap exclusively points crawlers toward public, static landing pages (/ and /login)
+// and entirely omits private authenticated routes, ensuring search engines index exactly what
+// new users are meant to discover, thus improving overall crawlability and discoverability.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** Added `app/robots.ts` and `app/sitemap.ts` to implement explicit crawler directives via Next.js Metadata API.
🎯 **Why:** Previously, the app lacked instructions for search crawlers. Authenticated routes (like `/dashboard`, `/inventory`, `/luggage`) were exposed to crawling but would result in redirect loops or generic error pages for unauthenticated crawler bots, wasting crawl budget and potentially harming domain authority. This change explicitly allows crawling for only the core landing pages (`/` and `/login`) while strictly disallowing private and dynamic areas.
📊 **Impact:** Increases discoverability of the main landing pages via the explicit XML sitemap, while protecting crawl budget and preventing search engines from attempting to index internal application routes.
🔬 **Verification:**
1. Ran `pnpm lint` and confirmed successful validation.
2. Ran `pnpm test` (Unit) and confirmed logic remained intact.
3. Verified the contents of `robots.ts` and `sitemap.ts` matched the intended route allowances.
🔗 **References:** [Next.js App Router robots.txt](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots), [Next.js App Router sitemap.xml](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [17759638052441155843](https://jules.google.com/task/17759638052441155843) started by @mvng*