### PR TITLE
🔧 Fix: Surface trip notes in trip view with auto-save

### DIFF
--- a/.jules/felix.md
+++ b/.jules/felix.md
@@ -1,0 +1,3 @@
+## 2024-03-31 - [Trip Notes Save Bug]
+**Learning:** When building auto-save `onBlur` components, comparing the current input value against the `initialValue` prop to bail out early is an anti-pattern. If a user modifies the input (triggering a save) and then later reverts the input back to the `initialValue`, the bailout check will falsely trigger, preventing the backend from being updated back to the initial state.
+**Action:** Always introduce a dedicated `lastSavedValue` state variable to track the *most recently saved* state. Compare against `lastSavedValue` rather than `initialValue` inside the `onBlur` handler to correctly trigger saves even when reverting to the initial prop value.

--- a/app/trip/[id]/TripPageClient.tsx
+++ b/app/trip/[id]/TripPageClient.tsx
@@ -11,6 +11,7 @@ import TripCountdown from '@/components/TripCountdown'
 import EditTripModal from '@/components/EditTripModal'
 import PackingRating from '@/components/PackingRating'
 import TripMembersSection from '@/components/TripMembersSection'
+import TripNotes from '@/components/TripNotes'
 import { formatDate } from '@/lib/utils'
 import dynamic from 'next/dynamic'
 import { Calendar, Check, RefreshCw } from 'lucide-react'
@@ -269,6 +270,9 @@ export default function TripPageClient({ initialTrip, user, isOwner, initialTrip
             <TripMembersSection tripId={trip.id} members={trip.members || []} isOwner={isOwner} />
           </div>
         </div>
+
+        {/* Trip Notes Section */}
+        <TripNotes tripId={trip.id} initialNotes={trip.notes} readOnly={isSharedView} />
 
         {/* View toggle */}
         {!isSharedView && (

--- a/components/TripNotes.tsx
+++ b/components/TripNotes.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import { updateTrip } from '@/actions/trip.actions'
+import { CheckCircle2 } from 'lucide-react'
+
+interface TripNotesProps {
+  tripId: string
+  initialNotes: string | null
+  readOnly?: boolean
+}
+
+export default function TripNotes({ tripId, initialNotes, readOnly = false }: TripNotesProps) {
+  const [notes, setNotes] = useState(initialNotes || '')
+  const [lastSavedNotes, setLastSavedNotes] = useState(initialNotes || '')
+  const [isSaving, setIsSaving] = useState(false)
+  const [showSaved, setShowSaved] = useState(false)
+  const MAX_CHARS = 500
+
+  const handleBlur = async () => {
+    if (readOnly || notes === lastSavedNotes) return
+
+    setIsSaving(true)
+    try {
+      await updateTrip(tripId, { notes })
+      setLastSavedNotes(notes)
+      setShowSaved(true)
+      setTimeout(() => setShowSaved(false), 2000)
+    } catch (error) {
+      console.error('Failed to save notes:', error)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (readOnly) {
+    if (!initialNotes) return null
+    return (
+      <div className="bg-white rounded-2xl border border-gray-100 p-6 mb-6">
+        <h3 className="font-semibold text-gray-900 mb-3 flex items-center gap-2">
+          <span>📝</span> Trip Notes
+        </h3>
+        <p className="text-gray-700 whitespace-pre-wrap">{initialNotes}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 p-6 mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="font-semibold text-gray-900 flex items-center gap-2">
+          <span>📝</span> Trip Notes
+        </h3>
+        <div className="flex items-center gap-3">
+          {isSaving && <span className="text-xs text-gray-400">Saving...</span>}
+          {showSaved && (
+            <span className="text-xs text-green-600 flex items-center gap-1 transition-opacity">
+              <CheckCircle2 className="w-3 h-3" /> Saved
+            </span>
+          )}
+          <span className={`text-xs ${notes.length >= MAX_CHARS ? 'text-red-500 font-medium' : 'text-gray-400'}`}>
+            {notes.length} / {MAX_CHARS}
+          </span>
+        </div>
+      </div>
+      <textarea
+        value={notes}
+        onChange={(e) => setNotes(e.target.value.slice(0, MAX_CHARS))}
+        onBlur={handleBlur}
+        placeholder="Add any notes, booking references, or reminders for this trip..."
+        className="w-full h-32 p-3 bg-gray-50 border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none transition-all text-sm text-gray-700 placeholder:text-gray-400"
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
🐛 **Issue:** Closes #188
🔍 **Root Cause:** The `Trip.notes` field existed in the Prisma schema and the trip edit modal, but it was not surfaced as a dedicated free-form area in the trip detail view as requested in the original enhancement schedule (#48).
🛠️ **Fix:** Created a `TripNotes` component and integrated it into the `TripPageClient` (below the members section). The component features an auto-save text area on blur, a 500-character limit with a counter, a visual "Saved" confirmation indicator, and supports a read-only mode for shared trip views. Resolved a state bug where reverting text to the original state prevented auto-saving.
✅ **Verification:** Verified using Playwright headless evaluation to ensure the component renders beautifully with Tailwind in both "Edit Mode" and "Read-Only Mode". Ran all unit tests and passed formatting.
⚠️ **Notes:** Integrates nicely into the existing `updateTrip` server action. Auto-save fires strictly on `onBlur` to match the specification without introducing unnecessary debounce polling logic on every keystroke.

---
*PR created automatically by Jules for task [15045625116123013688](https://jules.google.com/task/15045625116123013688) started by @mvng*