### PR TITLE
🔍 Scout: Add robots.txt and sitemap.xml for crawlability and discoverability

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,22 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/trip/',
+        '/inventory/',
+        '/luggage/',
+        '/claim/',
+        '/api/'
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** Added `app/robots.ts` and `app/sitemap.ts` to natively generate `robots.txt` and `sitemap.xml` for the Next.js App Router application.

🎯 **Why:** To improve SEO crawlability by explicitly guiding search engine crawlers toward public pages (like the homepage and login page) and explicitly blocking them from indexing private, authenticated user routes (like the dashboard, settings, trips, and API routes).

📊 **Impact:** Enhances the site's discoverability for public pages while ensuring user data and application state routes remain private and out of search engine indexes.

🔬 **Verification:**
- Ran `pnpm lint` and unit tests successfully.
- Verified file contents locally to ensure environment variables and fallback URLs are properly configured.
- Code review confirmed the implementation matches Next.js App Router standards.

🔗 **References:**
- Next.js Metadata Files: [Robots](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots) and [Sitemap](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [256034347613502753](https://jules.google.com/task/256034347613502753) started by @mvng*