### PR TITLE
🎨 Palette: Add accessible labels and focus rings to note editing actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Add aria-labels to inline note edit actions
+**Learning:** Found that inline edit action buttons (like Save/Cancel for packing list item notes) appearing conditionally next to textareas often omit `aria-label`s and focus rings, making them inaccessible to screen readers and difficult to navigate via keyboard.
+**Action:** Always ensure that icon-only buttons used for inline edit confirmation/cancellation have descriptive `aria-label` attributes and explicit focus rings (`focus:ring-2`) for keyboard users.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -725,9 +725,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         handleUpdateNotes(item.id, item.categoryId, item.packingListId, editingNotes?.notes || "")
                         setEditingNotes(null)
                       }}
-                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      aria-label="Save notes"
+                      title="Save notes"
+                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button
+                      onClick={() => setEditingNotes(null)}
+                      aria-label="Cancel"
+                      title="Cancel"
+                      className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1"
+                    ><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -1241,9 +1248,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                               handleUpdateNotes(item.id, category.id, list.id, editingNotes?.notes || "")
                                               setEditingNotes(null)
                                             }}
-                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                                            aria-label="Save notes"
+                                            title="Save notes"
+                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
                                           ><Check className="w-3 h-3" /></button>
-                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                                          <button
+                                            onClick={() => setEditingNotes(null)}
+                                            aria-label="Cancel"
+                                            title="Cancel"
+                                            className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1"
+                                          ><X className="w-3 h-3" /></button>
                                         </div>
                                       </div>
                                     ) : item.notes ? (


### PR DESCRIPTION
💡 What: Added `aria-label`, `title`, and `focus:ring-2` styling to the "Save" and "Cancel" buttons used during inline editing of packing list notes.
🎯 Why: To make the inline editing action buttons accessible to screen readers and improve visibility for keyboard users navigating the form.
📸 Before/After: Before, tab navigation showed no clear focus ring on these small buttons, and screen readers received no context. Now, they highlight with a blue/gray ring and announce "Save notes" and "Cancel" respectively.
♿ Accessibility: Improved keyboard navigation (`focus:ring-2`, `focus:ring-offset-1`) and screen reader support (`aria-label`) for icon-only conditional buttons.

---
*PR created automatically by Jules for task [16943225204439354117](https://jules.google.com/task/16943225204439354117) started by @mvng*