### PR TITLE
🎨 Palette: Add keyboard accessibility and aria-labels to inventory category items

### DIFF
--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -118,7 +118,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={"Edit " + item.name}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +139,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={"Delete " + item.name}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What: Added `aria-label`s and `focus-visible` states to the "Edit" and "Delete" icon-only buttons in the Inventory Category list.
🎯 Why: Improves screen reader context and allows keyboard-only users to see and interact with these actions, which were previously only visible on mouse hover.
📸 Before/After: Visual focus rings added and opacity fixed for keyboard focus.
♿ Accessibility: Screen reader users now hear context-aware labels ("Edit [item name]") instead of unlabelled buttons, and keyboard navigation visually reveals the buttons.

---
*PR created automatically by Jules for task [11773177658665801533](https://jules.google.com/task/11773177658665801533) started by @mvng*