### PR TITLE
🔍 Scout: Add dynamic sitemap for public routes

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-03-16 - [Sitemap for Public Routes]
+**Learning:** To generate a sitemap in Next.js App Router, implement an `app/sitemap.ts` file returning a `MetadataRoute.Sitemap` array. Only include public static routes (e.g., `/`, `/login`) and omit private or unlisted dynamic routes (e.g., `/claim/[token]`).
+**Action:** Always ensure public applications have a `sitemap.ts` to guide search engine crawlers.

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Generating a sitemap explicitly lists the public, indexable routes of the application
+// for search engine crawlers. We intentionally omit authenticated routes (like /dashboard)
+// and private unlisted routes (like /claim/[token]) to ensure crawl budgets are spent
+// only on pages that can actually appear in search results.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 What: Implemented Next.js App Router `app/sitemap.ts` to generate `sitemap.xml` for public routes (`/` and `/login`).
🎯 Why: Improves crawlability by explicitly providing search engines with a list of indexable, public-facing pages, omitting private dashboard and unlisted claim routes.
📊 Impact: Enhances search engine discovery and indexing efficiency for the homepage and login page.
🔬 Verification: Navigate to `/sitemap.xml` in the browser or use an XML validator to confirm the generated output.
🔗 References: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap

---
*PR created automatically by Jules for task [9721402389741857378](https://jules.google.com/task/9721402389741857378) started by @mvng*