### PR TITLE
🎨 Palette: Improve keyboard accessibility and screen reader support for icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2025-04-03 - Added ARIA labels and Focus Rings to Icon-Only Buttons
+**Learning:** React elements utilizing `opacity-0 group-hover:opacity-100` are invisible to sighted keyboard users unless accompanied by `focus-within:opacity-100` on the parent group or explicitly styling the element with `focus-visible:opacity-100`. Missing `aria-label`s on generic inline action buttons ("✕" or "✓") prevent screen reader users from understanding the button context.
+**Action:** Always provide explicit `aria-label`s, `title`s, and visually distinct focus rings (`focus-visible:ring-2`) to icon-only action buttons. For nested action buttons inside hover groups, ensure keyboard focus triggers their visibility.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -1241,9 +1241,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                               handleUpdateNotes(item.id, category.id, list.id, editingNotes?.notes || "")
                                               setEditingNotes(null)
                                             }}
-                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-1"
+                                            aria-label="Save note"
+                                            title="Save note"
                                           ><Check className="w-3 h-3" /></button>
-                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                                          <button
+                                            onClick={() => setEditingNotes(null)}
+                                            className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-1"
+                                            aria-label="Cancel editing note"
+                                            title="Cancel"
+                                          ><X className="w-3 h-3" /></button>
                                         </div>
                                       </div>
                                     ) : item.notes ? (

--- a/components/PlanningBoardView.tsx
+++ b/components/PlanningBoardView.tsx
@@ -497,7 +497,12 @@ function DayColumn({
               <span className="text-sm">{allDayTag.icon}</span>
               <span className={`text-[11px] font-semibold ${headerText} opacity-90`}>{allDayTag.label}</span>
               <span className={`text-[10px] ml-0.5 opacity-50 ${headerText}`}>— all day</span>
-              <button onClick={() => saveLabel('')} className={`ml-auto text-[11px] opacity-60 hover:opacity-100 ${headerText} focus:outline-none leading-none`}>✕</button>
+              <button
+                onClick={() => saveLabel('')}
+                className={`ml-auto text-[11px] opacity-60 hover:opacity-100 ${headerText} focus:outline-none focus-visible:ring-2 focus-visible:ring-current rounded-sm leading-none`}
+                aria-label="Remove all day label"
+                title="Remove label"
+              >✕</button>
             </div>
           ) : editingLabel ? (
             <input autoFocus type="text" value={labelInput}

--- a/components/TripWeatherDetailClient.tsx
+++ b/components/TripWeatherDetailClient.tsx
@@ -22,7 +22,7 @@ export default function TripWeatherDetailClient({ weather, headerChildren, expan
       {/* Ultra-compact preview - no capped warning when collapsed */}
       <button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full px-3 py-2 flex items-center justify-between hover:bg-white hover:bg-opacity-30 transition-colors text-left gap-2"
+        className="w-full px-3 py-2 flex items-center justify-between hover:bg-white hover:bg-opacity-30 transition-colors text-left gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-inset rounded-lg"
         aria-expanded={isExpanded}
         aria-controls="weather-details"
       >


### PR DESCRIPTION
💡 What: Added `aria-label`s, `title` attributes, and explicit `focus-visible:ring-2` styles to icon-only buttons across the Planning Board, Weather Widget, and Packing List.
🎯 Why: To ensure screen reader users have context for icon-only actions and keyboard users can clearly see which interactive element currently has focus.
📸 Before/After: N/A
♿ Accessibility: Improved keyboard focus visibility and added context-aware ARIA labeling to previously inaccessible buttons.

---
*PR created automatically by Jules for task [16278874303222531974](https://jules.google.com/task/16278874303222531974) started by @mvng*