### PR TITLE
⚡ Bolt: Memoize derived packing list items to prevent expensive re-renders

### DIFF
--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useTransition, useEffect, useCallback, useOptimistic } from 'react'
+import { useState, useTransition, useEffect, useCallback, useOptimistic, useMemo } from 'react'
 import { toggleItemPacked, addCustomItem, deleteItem, togglePackLast, updateItemNotes, assignItemToMember, generateShareToken } from '@/actions/packing.actions'
 import { getTripLuggage, assignItemToLuggage, removeLuggageFromTrip } from '@/actions/luggage.actions'
 import InventoryPickerModal from '@/components/inventory/InventoryPickerModal'
@@ -560,10 +560,10 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
     return tl.luggage.icon || luggageIcons[tl.luggage.type as LuggageType]
   }
 
-  const getItemPackedState = (item: PackingItem): boolean => {
+  const getItemPackedState = useCallback((item: PackingItem): boolean => {
     if (readOnly) return localPackedState[item.id] ?? item.isPacked
     return item.isPacked
-  }
+  }, [readOnly, localPackedState])
 
   const handleShareToClaim = async (packingListId: string) => {
     if (readOnly) return
@@ -579,36 +579,40 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
     }
   }
 
-  const allItems = optimisticLists.flatMap(list =>
-    list.categories.flatMap(cat =>
-      cat.items.map(item => ({
-        ...item,
-        categoryId: cat.id,
-        categoryName: cat.name,
-        packingListId: list.id,
-        isPacked: getItemPackedState(item)
-      }))
+  const { allItems, packLastItems, itemsByLuggage, itemsByPerson } = useMemo(() => {
+    const allItems = optimisticLists.flatMap(list =>
+      list.categories.flatMap(cat =>
+        cat.items.map(item => ({
+          ...item,
+          categoryId: cat.id,
+          categoryName: cat.name,
+          packingListId: list.id,
+          isPacked: getItemPackedState(item)
+        }))
+      )
     )
-  )
 
-  const packLastItems = !readOnly ? allItems.filter(item => item.packLast) : []
-  const regularItems = allItems.filter(item => !item.packLast)
+    const packLastItems = !readOnly ? allItems.filter(item => item.packLast) : []
+    const regularItems = allItems.filter(item => !item.packLast)
 
-  const itemsByLuggage: Record<string, typeof allItems> = {
-    'not-assigned': regularItems.filter(item => !item.tripLuggageId)
-  }
-  optimisticTripLuggages.forEach(tl => {
-    itemsByLuggage[tl.id] = regularItems.filter(item => item.tripLuggageId === tl.id)
-  })
-
-  const itemsByPerson: Record<string, typeof allItems> = {
-    'not-assigned': regularItems.filter(item => !item.assigneeId)
-  }
-  if (trip.members) {
-    trip.members.forEach(member => {
-      itemsByPerson[member.id] = regularItems.filter(item => item.assigneeId === member.id)
+    const itemsByLuggage: Record<string, typeof allItems> = {
+      'not-assigned': regularItems.filter(item => !item.tripLuggageId)
+    }
+    optimisticTripLuggages.forEach(tl => {
+      itemsByLuggage[tl.id] = regularItems.filter(item => item.tripLuggageId === tl.id)
     })
-  }
+
+    const itemsByPerson: Record<string, typeof allItems> = {
+      'not-assigned': regularItems.filter(item => !item.assigneeId)
+    }
+    if (trip.members) {
+      trip.members.forEach(member => {
+        itemsByPerson[member.id] = regularItems.filter(item => item.assigneeId === member.id)
+      })
+    }
+
+    return { allItems, packLastItems, itemsByLuggage, itemsByPerson }
+  }, [optimisticLists, optimisticTripLuggages, trip.members, readOnly, getItemPackedState])
 
   const renderItem = (item: typeof allItems[0]) => {
     const isPacked = getItemPackedState(item)


### PR DESCRIPTION
💡 What: Used `useMemo` for derived lists (`allItems`, `itemsByLuggage`, `itemsByPerson`) and `useCallback` for `getItemPackedState` in `PackingListSection.tsx`.
🎯 Why: Derived data calculations using `.flatMap()` and `.filter()` over all lists, categories, and items were occurring on every render. Because the array objects changed, this caused significant UI lag when typing into item notes or toggling groups.
📊 Impact: Significantly reduces the computational cost of re-renders by skipping O(N) operations when underlying list data hasn't changed.
🔬 Measurement: Observe improved responsiveness in the browser while editing a text input (e.g. item notes) within the packing list view, which previously triggered full array recalculations.

---
*PR created automatically by Jules for task [227706203982587349](https://jules.google.com/task/227706203982587349) started by @mvng*