### PR TITLE
🔍 Scout: Add sitemap and robots.txt for search visibility

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-03-15 - [Sitemap and Robots generation in Next.js App Router]
+**Learning:** Adding a sitemap directly in the `app` directory as `sitemap.ts` and configuring crawling rules in `robots.ts` natively provides SEO crawlers with explicit instructions. This vastly improves indexability for public pages while preventing wasted crawl budget on private/authenticated routes. Remember that `rules` returned from `robots()` can be interpreted differently depending on array or single-object implementation and must be unit-tested accordingly.
+**Action:** When implementing basic SEO technical setup, use native `sitemap.ts` and `robots.ts` over third-party libraries for better performance. Ensure to include comments explaining the SEO rationale to adhere strictly to rules and maintain clear documentation.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// The robots.txt file guides search engine crawlers away from private, authenticated routes.
+// This prevents crawlers from wasting crawl budget on pages they cannot access and avoids
+// accidental indexing of sensitive user-specific URL paths.
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/trip/',
+        '/luggage/',
+        '/inventory/',
+        '/claim/',
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Adding a sitemap explicitly declares to search engine crawlers which pages are available
+// to be indexed, their relative priority, and their update frequency. This significantly
+// improves discoverability for core static and public-facing pages.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/sitemap_robots_seo.test.ts
+++ b/tests/sitemap_robots_seo.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import robots from '../app/robots';
+import sitemap from '../app/sitemap';
+
+test.describe('SEO Generation', () => {
+  test('robots.txt should allow / and disallow private routes', () => {
+    const robotsData = robots();
+    expect(robotsData.rules).toBeDefined();
+    if (Array.isArray(robotsData.rules)) {
+      expect(robotsData.rules[0].allow).toBe('/');
+      expect(robotsData.rules[0].disallow).toContain('/dashboard/');
+    } else {
+      expect(robotsData.rules.allow).toBe('/');
+      expect(robotsData.rules.disallow).toContain('/dashboard/');
+    }
+  });
+
+  test('sitemap.xml should contain static public routes', () => {
+    const sitemapData = sitemap();
+    expect(sitemapData.length).toBeGreaterThan(0);
+    const urls = sitemapData.map(entry => entry.url);
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+    expect(urls.some(url => url === baseUrl)).toBe(true);
+    expect(urls.some(url => url.endsWith('/login'))).toBe(true);
+  });
+});


### PR DESCRIPTION
💡 What: Added `sitemap.ts` and `robots.ts` for Next.js App Router.
🎯 Why: Improves site crawlability by explicitly guiding search engines to public pages and preventing them from crawling private routes.
📊 Impact: Search engines can now efficiently discover and index the homepage and login page, while ignoring authenticated dashboard pages.
🔬 Verification: Verify by visiting `/sitemap.xml` and `/robots.txt` in a browser or Next.js development server to see the generated files.
🔗 References: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap, https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots

---
*PR created automatically by Jules for task [17702085761053129319](https://jules.google.com/task/17702085761053129319) started by @mvng*