### PR TITLE
🎨 Palette: Add ARIA labels and focus indicators to TaskCard buttons

### DIFF
--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -34,8 +34,9 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
     >
       <div className="flex items-start gap-3">
         <button
+          aria-label={isDone ? 'Mark task as pending' : 'Mark task as done'}
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,17 +71,19 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className={`flex items-center gap-1 transition-opacity focus-within:opacity-100 ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
           <button
+            aria-label="Edit task"
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
+            aria-label="Delete task"
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
           >
             <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
💡 What: Add ARIA labels and keyboard focus indicators to icon-only buttons in `TaskCard`.
🎯 Why: Improve accessibility for screen reader users and keyboard navigation.
📸 Before/After: n/a
♿ Accessibility: Added descriptive `aria-label` attributes to toggle status, edit, and delete buttons. Added `focus-visible:ring-2 focus-visible:outline-none` styles for clear keyboard focus state, and `focus-within:opacity-100` to their container so they remain visible when focused without a mouse.
🔗 References: n/a

---
*PR created automatically by Jules for task [4464396945688453273](https://jules.google.com/task/4464396945688453273) started by @mvng*