### PR TITLE
🎨 Palette: Add Escape key support to inventory modals

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Add Escape key support to inventory modals
+**Learning:** Found that some modals in the inventory section (`AddItemModal`, `AddCategoryModal`) were missing the `Escape` key close handler that is standard across other modals in the application. Also learned that when adding event listeners to React components using `useEffect`, they should be kept in a separate hook rather than merged into existing on-mount hooks (like those handling initial focus) to avoid unintended side effects on re-renders.
+**Action:** Always ensure that custom modal components implement an `Escape` keydown event listener attached to the `document` (with proper unmount cleanup) that triggers the modal's close function. When adding such listeners, separate them into their own `useEffect` hooks.

--- a/components/inventory/AddCategoryModal.tsx
+++ b/components/inventory/AddCategoryModal.tsx
@@ -20,6 +20,17 @@ export default function AddCategoryModal({
     inputRef.current?.focus()
   }, [])
 
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [onClose])
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!name.trim()) return

--- a/components/inventory/AddItemModal.tsx
+++ b/components/inventory/AddItemModal.tsx
@@ -27,6 +27,17 @@ export default function AddItemModal({
     inputRef.current?.focus()
   }, [])
 
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [onClose])
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!name.trim()) return


### PR DESCRIPTION
💡 **What:** Added `Escape` key support to close the `AddCategoryModal` and `AddItemModal` components in the inventory section. Also refactored the `useEffect` hooks to properly isolate the event listeners from the initial focus logic.

🎯 **Why:** To improve keyboard accessibility and provide a consistent, intuitive user experience across all modal components in the application.

📸 **Before/After:** N/A (Interaction-only change, UI remains visually identical).

♿ **Accessibility:** Keyboard users can now dismiss these inventory modals using the Escape key, bringing them in line with expected standard modal behavior.

---
*PR created automatically by Jules for task [13619909403200822365](https://jules.google.com/task/13619909403200822365) started by @mvng*