### PR TITLE
🔍 Scout: Add sitemap generation for crawlability

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test'
+import sitemap from '../app/sitemap'
+
+test('sitemap generates correct public routes', () => {
+  const result = sitemap()
+
+  expect(result).toHaveLength(2)
+  expect(result[0].url).toMatch(/\/$/)
+  expect(result[1].url).toMatch(/\/login$/)
+  expect(result[0].priority).toBe(1)
+  expect(result[1].priority).toBe(0.8)
+})


### PR DESCRIPTION
💡 **What:** Added a dynamic Next.js `sitemap.ts` file to generate a `sitemap.xml` for public static routes (`/` and `/login`), utilizing the base URL from environment variables with a fallback. Also included a unit test to verify the correctness of the generated sitemap structure and URLs.

🎯 **Why:** To improve search engine crawlability by explicitly defining the site's public URLs, their priority, and change frequency. This ensures crawlers efficiently index the available landing and authentication pages.

📊 **Impact:** Enhances the site's visibility on search engines by ensuring the primary entry points are easily discovered and appropriately prioritized for indexing.

🔬 **Verification:** Verified by a new unit test `tests/sitemap.test.ts` that checks the output of `sitemap()`, verifying the generated array has the correct lengths, URL paths, and priorities. Additionally, ran `pnpm lint` and `pnpm test` (with dummy env variables set) locally.

🔗 **References:** Based on [Next.js App Router Documentation for Sitemap Generation](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap).

---
*PR created automatically by Jules for task [11041142291740664995](https://jules.google.com/task/11041142291740664995) started by @mvng*