### PR TITLE
🎨 Palette: Add aria-labels and focus states to inline note edit buttons

### DIFF
--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -725,9 +725,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         handleUpdateNotes(item.id, item.categoryId, item.packingListId, editingNotes?.notes || "")
                         setEditingNotes(null)
                       }}
-                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+                      title="Save note"
+                      aria-label="Save note"
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button
+                      onClick={() => setEditingNotes(null)}
+                      className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-1"
+                      title="Cancel"
+                      aria-label="Cancel editing note"
+                    ><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -1241,9 +1248,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                               handleUpdateNotes(item.id, category.id, list.id, editingNotes?.notes || "")
                                               setEditingNotes(null)
                                             }}
-                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+                                            title="Save note"
+                                            aria-label="Save note"
                                           ><Check className="w-3 h-3" /></button>
-                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                                          <button
+                                            onClick={() => setEditingNotes(null)}
+                                            className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-1"
+                                            title="Cancel"
+                                            aria-label="Cancel editing note"
+                                          ><X className="w-3 h-3" /></button>
                                         </div>
                                       </div>
                                     ) : item.notes ? (


### PR DESCRIPTION
💡 What: Added descriptive `aria-label`s, `title`s, and Tailwind CSS focus states (`focus:outline-none`, `focus:ring-2`, `focus:ring-offset-1`) to the icon-only "Save" and "Cancel" buttons used during inline note editing within the `PackingListSection` component.
🎯 Why: Without these attributes, screen reader users and keyboard navigators lack context about what the identical checkmark and "x" buttons do. The focus classes provide clear visual feedback during keyboard navigation.
📸 Before/After: Visual focus rings are now appropriately displayed around the check/X icons when tabbed onto via keyboard (verified via Playwright).
♿ Accessibility: Improved keyboard focus visibility and screen reader comprehension.

---
*PR created automatically by Jules for task [8378622001797505704](https://jules.google.com/task/8378622001797505704) started by @mvng*