### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in packing lists

### DIFF
--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -725,9 +725,11 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         handleUpdateNotes(item.id, item.categoryId, item.packingListId, editingNotes?.notes || "")
                         setEditingNotes(null)
                       }}
-                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      aria-label="Save note"
+                      title="Save note"
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400" aria-label="Cancel editing note" title="Cancel editing note"><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -1241,9 +1243,11 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                               handleUpdateNotes(item.id, category.id, list.id, editingNotes?.notes || "")
                                               setEditingNotes(null)
                                             }}
-                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                            aria-label="Save note"
+                                            title="Save note"
                                           ><Check className="w-3 h-3" /></button>
-                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400" aria-label="Cancel editing note" title="Cancel editing note"><X className="w-3 h-3" /></button>
                                         </div>
                                       </div>
                                     ) : item.notes ? (
@@ -1263,14 +1267,20 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                   <button
                                     onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
                                     title="Add/Edit Note"
+                                    aria-label="Add or Edit Note"
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
                                   ><MessageSquare className="w-3.5 h-3.5" /></button>
                                   <button
                                     onClick={() => handleTogglePackLast(item.id, category.id, list.id, item.packLast)}
-                                    title="Add to departure checklist"
-                                    className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center"
+                                    title={item.packLast ? 'Remove from departure checklist' : 'Add to departure checklist'}
+                                    aria-label={item.packLast ? 'Remove from pack last' : 'Mark as pack last'}
+                                    className={`text-xs p-1 rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center ${
+                                      item.packLast
+                                        ? 'bg-amber-100 text-amber-700 border-amber-300'
+                                        : 'bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600'
+                                    }`}
                                   ><Sunrise className="w-3.5 h-3.5" /></button>
-                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
+                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} aria-label={"Remove " + item.name + " from list"} title="Remove item" className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
                                 </div>
                               )}
                             </li>


### PR DESCRIPTION
💡 What: Added `aria-label`s, descriptive `title`s, and focus state styling to icon-only buttons in the packing list items components.
🎯 Why: To improve screen reader accessibility and keyboard navigation. The icon-only buttons (save, cancel, edit note, pack last, and delete) lacked labels and visible focus rings, making them inaccessible to assistive tech.
📸 Before/After: Visual changes are mostly focus rings. A screenreader will now announce actions properly.
♿ Accessibility: Improved keyboard focus and screen reader announcements for the interactive action menu on packing list items.

---
*PR created automatically by Jules for task [14040663861172770906](https://jules.google.com/task/14040663861172770906) started by @mvng*