### PR TITLE
🔍 Scout: Add sitemap.xml for improved crawlability

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,7 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+
+## 2025-04-05 - [App Router Sitemap Implementation]
+**Learning:** Next.js App Router natively supports a simple `app/sitemap.ts` file returning a `MetadataRoute.Sitemap` array, which automatically generates a `/sitemap.xml` endpoint without needing external plugins. This must selectively omit authenticated endpoints (like `/dashboard`) as crawlers cannot index them anyway.
+**Action:** Always utilize the native `app/sitemap.ts` to expose static and unauthenticated dynamic routes for Next.js applications, ensuring a fallback environmental base URL is provided.

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,31 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Adding a sitemap.xml ensures search engines can easily discover and index the public
+// pages of Packwise. We omit protected routes (like /dashboard, /inventory, /settings)
+// and dynamic, unlisted routes (like /claim/[token]) because they require authentication
+// or are meant for direct sharing, preventing search engine crawlers from accessing them anyway.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/ds`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  ]
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import sitemap from '../app/sitemap';
+
+test.describe('SEO Tests', () => {
+  test('sitemap should generate correctly and contain only public routes', () => {
+    // Generate the sitemap
+    const generatedSitemap = sitemap();
+
+    // Check that we have exactly 3 entries
+    expect(generatedSitemap.length).toBe(3);
+
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+
+    // Extract the URLs from the sitemap
+    const urls = generatedSitemap.map(item => item.url);
+
+    // Verify all expected URLs are present
+    expect(urls).toContain(`${baseUrl}`);
+    expect(urls).toContain(`${baseUrl}/login`);
+    expect(urls).toContain(`${baseUrl}/ds`);
+
+    // Verify properties of the home route
+    const homeRoute = generatedSitemap.find(item => item.url === `${baseUrl}`);
+    expect(homeRoute).toBeDefined();
+    expect(homeRoute?.priority).toBe(1);
+    expect(homeRoute?.changeFrequency).toBe('weekly');
+    expect(homeRoute?.lastModified).toBeInstanceOf(Date);
+  });
+});


### PR DESCRIPTION
💡 **What**
Implemented Next.js native sitemap generation by adding an `app/sitemap.ts` file which exposes `/sitemap.xml` for search engine bots. It strictly includes public routes like `/`, `/login`, and `/ds` and omits protected or dynamic share routes.

🎯 **Why**
Providing a valid `sitemap.xml` allows search engines to systematically crawl and discover the publicly indexable surfaces of the Packwise web application more efficiently than relying on simple link traversal.

📊 **Impact**
Improves search engine discovery and ensures that key public pages (the main application landing page, authentication page, and design system page) are accurately represented to web crawlers. The PR does not alter any existing UI functionality and operates < 50 lines.

🔬 **Verification**
A Playwright unit test (`tests/seo.test.ts`) has been included which natively executes `sitemap()` and verifies it returns exactly the expected array structure and prioritizations. All checks have run correctly locally.

🔗 **References**
- [Next.js App Router Sitemap docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)
- [Google Search Central: Sitemaps](https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview)

---
*PR created automatically by Jules for task [18191838196174423844](https://jules.google.com/task/18191838196174423844) started by @mvng*