### PR TITLE
🎨 Palette: Add ARIA labels and focus styles to icon buttons

### DIFF
--- a/components/LaundryToggle.tsx
+++ b/components/LaundryToggle.tsx
@@ -40,10 +40,11 @@ export default function LaundryToggle({ startDate, endDate, onChange }: LaundryT
         </div>
         <button
           onClick={() => handleToggle(!hasLaundry)}
-          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none ${
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
             hasLaundry ? 'bg-blue-600' : 'bg-gray-200'
           }`}
           aria-pressed={hasLaundry}
+          aria-label="Toggle laundry access"
         >
           <span
             className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -725,9 +725,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         handleUpdateNotes(item.id, item.categoryId, item.packingListId, editingNotes?.notes || "")
                         setEditingNotes(null)
                       }}
-                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-500"
+                      aria-label="Save note"
+                      title="Save note"
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button
+                      onClick={() => setEditingNotes(null)}
+                      className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-gray-400"
+                      aria-label="Cancel editing note"
+                      title="Cancel editing note"
+                    ><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -748,6 +755,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
             <button
               onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
               title="Add/Edit Note"
+              aria-label="Add or Edit Note"
               className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
             ><MessageSquare className="w-3.5 h-3.5" /></button>
             <button


### PR DESCRIPTION
💡 **What**: Added descriptive `aria-label`s, tooltips (`title`s), and explicit `focus`/`focus-visible` ring utility classes to icon-only interactive elements in `PackingListSection.tsx` and `LaundryToggle.tsx`.

🎯 **Why**: Previously, icon-only buttons like the Save/Cancel actions for inline notes and the Laundry Access toggle lacked accessible names and clear visual focus indicators. This makes the interface difficult to navigate for keyboard users and screen readers.

📸 **Before/After**: Visually, standard mouse users will now see browser-native tooltips on hover for note actions, and keyboard users will now see distinct blue/gray outline rings when tabbing through these elements.

♿ **Accessibility**: 
- Screen readers can now articulate "Save note", "Cancel editing note", "Add or Edit Note", and "Toggle laundry access".
- Keyboard users can now clearly identify which icon button is currently focused.

---
*PR created automatically by Jules for task [980793734749983653](https://jules.google.com/task/980793734749983653) started by @mvng*