### PR TITLE
🎨 Palette: [UX improvement] Add keyboard accessibility and ARIA labels to TaskCard icon buttons

### DIFF
--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -35,9 +35,10 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
+          aria-label={isDone ? "Mark as not done" : "Mark as done"}
         >
           {isDone ? <CheckCircle className="w-5 h-5" /> : <Circle className="w-5 h-5" />}
         </button>
@@ -70,18 +71,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0 focus-within:opacity-100'}`}>
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
+            aria-label="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
+            aria-label="Delete task"
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the Edit, Delete, and Status Toggle buttons in the `TaskCard` component. Also added explicit `focus-visible` styling to all interactive elements and `focus-within:opacity-100` to the hover-actions container.
🎯 Why: Previously, the Edit and Delete buttons were only visible on pointer hover (`opacity-0 group-hover:opacity-100`) and lacked ARIA labels, making them invisible and inaccessible to keyboard-only and screen reader users. The status toggle button also lacked focus styling.
📸 Before/After: Screenshots were captured demonstrating the new focus rings triggering the visibility of the action buttons container.
♿ Accessibility: Ensures that keyboard users can tab into and discover the action buttons, and screen reader users hear clear descriptions of what the icon-only buttons do.

---
*PR created automatically by Jules for task [15874217427621916957](https://jules.google.com/task/15874217427621916957) started by @mvng*