### PR TITLE
⚡ Bolt: Memoize template categories in new trip form

### DIFF
--- a/app/dashboard/new/page.tsx
+++ b/app/dashboard/new/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createTrip } from '@/actions/trip.actions'
@@ -118,10 +118,26 @@ export default function NewTripPage() {
   }
 
   const duration = getDurationDays(formData.startDate, formData.endDate)
-  const templateCategories = formData.generateSuggestions
-    ? generatePackingList(formData.tripType as "leisure" | "business" | "beach" | "hiking" | "city" | "skiing", duration, formData.transportMode)
-    : []
-  const totalItems = templateCategories.reduce((sum, c) => sum + c.items.length, 0)
+
+  // ⚡ Bolt Performance Optimization
+  // Why: The NewTripPage is a form with controlled inputs (e.g. name, destination). Without memoization,
+  // `generatePackingList` executes data processing and allocates memory on every single keystroke.
+  // Impact: Prevents UI lag by ensuring the template packing list is only recalculated when relevant
+  // fields (like trip duration or transport mode) actually change.
+  const templateCategories = useMemo(() => {
+    return formData.generateSuggestions
+      ? generatePackingList(formData.tripType as "leisure" | "business" | "beach" | "hiking" | "city" | "skiing", duration, formData.transportMode)
+      : []
+  }, [
+    formData.generateSuggestions,
+    formData.tripType,
+    formData.transportMode,
+    duration
+  ])
+
+  // ⚡ Bolt Performance Optimization
+  // Why: Avoids iterating through the entire templateCategories array on every render cycle.
+  const totalItems = useMemo(() => templateCategories.reduce((sum, c) => sum + c.items.length, 0), [templateCategories])
 
   return (
     <div className="min-h-screen bg-gray-50 py-12">


### PR DESCRIPTION
💡 What: Wrapped `templateCategories` generation and `totalItems` reduction inside `useMemo` hooks in the `NewTripPage` component.
🎯 Why: `NewTripPage` contains controlled inputs (e.g., Trip Name, City / Location) that trigger a re-render on every keystroke. Without memoization, `generatePackingList` executes heavy data processing and memory reallocation synchronously for each keystroke, creating potential UI lag.
📊 Impact: Eliminates O(N) recalculations on unrelated form field changes. The template list will now only regenerate when its actual dependencies (trip type, transport mode, start/end dates, or the suggestion toggle) change, improving typing responsiveness.
🔬 Measurement: Verified by observing zero lag when typing in the "Trip Name" or "Location" inputs while the template toggle is active. E2E tests for trip creation continue to pass successfully.

---
*PR created automatically by Jules for task [12478064314984565669](https://jules.google.com/task/12478064314984565669) started by @mvng*