### PR TITLE
🔍 Scout: Add sitemap.xml generation

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Generating a sitemap.xml helps search engines (Google, Bing) discover, crawl, and index
+// the public-facing pages of the application more efficiently. By omitting private routes
+// (e.g. /dashboard, /settings), we focus crawl budget entirely on pages that can actually
+// rank in search results, preventing crawler waste.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test'
+import sitemap from '../app/sitemap'
+
+test.describe('Sitemap Generation', () => {
+  test('generates sitemap with correct public URLs', () => {
+    const sitemapData = sitemap()
+
+    expect(sitemapData).toBeDefined()
+    expect(sitemapData.length).toBeGreaterThan(0)
+
+    const urls = sitemapData.map(entry => entry.url)
+
+    // Check for public routes
+    expect(urls).toContain('https://packwise-indol.vercel.app')
+    expect(urls).toContain('https://packwise-indol.vercel.app/login')
+
+    // Ensure no private routes are included
+    expect(urls).not.toContain('https://packwise-indol.vercel.app/dashboard')
+    expect(urls).not.toContain('https://packwise-indol.vercel.app/settings')
+    expect(urls).not.toContain('https://packwise-indol.vercel.app/inventory')
+    expect(urls).not.toContain('https://packwise-indol.vercel.app/luggage')
+  })
+
+  test('uses NEXT_PUBLIC_APP_URL environment variable if provided', () => {
+    const originalEnv = process.env.NEXT_PUBLIC_APP_URL
+    process.env.NEXT_PUBLIC_APP_URL = 'https://custom-domain.com'
+
+    const sitemapData = sitemap()
+    const urls = sitemapData.map(entry => entry.url)
+
+    expect(urls).toContain('https://custom-domain.com')
+    expect(urls).toContain('https://custom-domain.com/login')
+
+    // Restore environment variable
+    process.env.NEXT_PUBLIC_APP_URL = originalEnv
+  })
+})


### PR DESCRIPTION
💡 What: Added dynamic sitemap.xml generation using Next.js App Router MetadataRoute.Sitemap in `app/sitemap.ts`.
🎯 Why: A sitemap helps search engines discover and crawl the public-facing pages more efficiently. By specifically omitting private routes (like /dashboard and /settings), we prevent wasting crawl budget on pages that search engines cannot index, ensuring they focus on pages that can actually rank.
📊 Impact: Improves crawl efficiency and visibility of public-facing pages, facilitating better indexing by Google and other search engines.
🔬 Verification: Run `npx playwright test tests/sitemap.test.ts --config playwright-unit.config.ts` to confirm only public routes are included and the structure is valid.
🔗 References: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap

---
*PR created automatically by Jules for task [7555068043043551401](https://jules.google.com/task/7555068043043551401) started by @mvng*