### PR TITLE
🔍 Scout: Add sitemap.xml and robots.txt

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-03-24 - [Sitemap and Robots Configuration]
+**Learning:** Adding a dynamic `sitemap.xml` and `robots.txt` explicitly controls crawler behavior, preventing indexing of authenticated routes (like `/dashboard`) while directing crawlers to public entry points. When unit testing these configurations, hardcoding fallback URLs in assertions causes brittle tests if `process.env.NEXT_PUBLIC_APP_URL` changes; tests should dynamically compute the `baseUrl` just like the source files.
+**Action:** Always include a `sitemap.ts` and `robots.ts` in Next.js applications, explicitly adding SEO rationale comments within the files, and ensure unit tests dynamically determine the `baseUrl` for assertions to avoid test fragility.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,17 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  // SEO Rationale: A robust robots.txt directs search crawlers toward the sitemap
+  // while explicitly disallowing private or authenticated routes, preventing
+  // duplicate content issues and preserving crawl budget.
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: ['/api/', '/dashboard/', '/settings/', '/claim/', '/trip/', '/inventory/', '/luggage/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,22 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  // SEO Rationale: Generating a dynamic sitemap.xml ensures search engine crawlers
+  // discover and index our core public landing pages efficiently.
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/robots.test.ts
+++ b/tests/robots.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+import robots from '../app/robots'
+
+test('robots generates correct rules and sitemap', () => {
+  const result = robots()
+
+  // Verify rules
+  const rules = result.rules
+  expect(rules).not.toBeNull()
+
+  if (Array.isArray(rules)) {
+    const rule = rules[0]
+    expect(rule.userAgent).toBe('*')
+    expect(rule.allow).toContain('/')
+    expect(rule.allow).toContain('/login')
+    expect(rule.disallow).toContain('/api/')
+    expect(rule.disallow).toContain('/dashboard/')
+  } else {
+    expect(rules!.userAgent).toBe('*')
+    expect(rules!.allow).toContain('/')
+    expect(rules!.allow).toContain('/login')
+    expect(rules!.disallow).toContain('/api/')
+    expect(rules!.disallow).toContain('/dashboard/')
+  }
+
+  // Verify sitemap
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  expect(result.sitemap).toBe(`${baseUrl}/sitemap.xml`)
+})

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test'
+import sitemap from '../app/sitemap'
+
+test('sitemap generates correct URLs', () => {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const result = sitemap()
+  expect(Array.isArray(result)).toBe(true)
+  expect(result.length).toBe(2)
+  expect(result[0].url).toContain(baseUrl)
+  expect(result[1].url).toContain(`${baseUrl}/login`)
+})


### PR DESCRIPTION
💡 **What:** Implemented `app/sitemap.ts` and `app/robots.ts` to dynamically generate `sitemap.xml` and `robots.txt` respectively.
🎯 **Why:** To guide search engine crawlers toward indexable public routes (`/`, `/login`) and explicitly prevent the indexing of authenticated or private routes (`/api/`, `/dashboard/`, `/settings/`, `/claim/`, `/trip/`, `/inventory/`, `/luggage/`), thereby optimizing crawl budget and preventing duplicate content issues.
📊 **Impact:** Improves SEO visibility for public landing pages and ensures sensitive application states aren't unintentionally indexed.
🔬 **Verification:** Run `pnpm test tests/sitemap.test.ts` and `pnpm test tests/robots.test.ts` to confirm proper URL generation.
🔗 **References:** [Next.js App Router Metadata Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [14213232630374342320](https://jules.google.com/task/14213232630374342320) started by @mvng*