### PR TITLE
🎨 Palette: Improve accessibility of member action buttons

### DIFF
--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -110,15 +110,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
-            title="Confirm"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+            title="Confirm adding member"
+            aria-label="Confirm adding member"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
-            title="Cancel"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+            title="Cancel adding member"
+            aria-label="Cancel adding member"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
💡 What: Added explicit `aria-label`s, improved `title`s, and implemented clear keyboard focus indicators (`focus-visible:ring-2`) to the "Confirm" and "Cancel" icon-only buttons in the `TripMembersSection` component.
🎯 Why: Icon-only buttons without `aria-label`s are invisible to screen readers, making the interface inaccessible for users relying on assistive technology. Furthermore, clear focus states are essential for users navigating via keyboard.
📸 Before/After: Verified visually via temporary Playwright scripts that the focus rings now correctly appear on keyboard focus.
♿ Accessibility: Improved screen reader support (via `aria-label`) and keyboard navigation support (via `focus-visible` utility classes) on interactive form elements.

---
*PR created automatically by Jules for task [987449179741548876](https://jules.google.com/task/987449179741548876) started by @mvng*