### PR TITLE
🎨 Palette: Add Escape key handler to inventory modals

### DIFF
--- a/components/inventory/AddCategoryModal.tsx
+++ b/components/inventory/AddCategoryModal.tsx
@@ -20,6 +20,14 @@ export default function AddCategoryModal({
     inputRef.current?.focus()
   }, [])
 
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [onClose])
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!name.trim()) return

--- a/components/inventory/AddItemModal.tsx
+++ b/components/inventory/AddItemModal.tsx
@@ -27,6 +27,14 @@ export default function AddItemModal({
     inputRef.current?.focus()
   }, [])
 
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [onClose])
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!name.trim()) return


### PR DESCRIPTION
💡 What: Added an `Escape` keydown event listener to both `AddCategoryModal` and `AddItemModal` in the inventory section.
🎯 Why: Keyboard-only users and screen reader users expect overlays and modals to be dismissible via the `Escape` key. This was a missing accessibility feature in these specific modals.
📸 Before/After: Visuals remain the same, but keyboard interaction is enabled.
♿ Accessibility: Improves WCAG compliance for modal dialogs by allowing easy keyboard dismissal without needing to tab to the explicit 'Cancel' button or click outside the modal.

---
*PR created automatically by Jules for task [4701165412741324069](https://jules.google.com/task/4701165412741324069) started by @mvng*