### PR TITLE
🔍 Scout: Add dynamic sitemap.xml and robots.txt generators

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,16 @@
+import { MetadataRoute } from 'next'
+
+// SEO Rationale: robots.txt guides search engine crawlers, ensuring they index valuable public pages
+// while keeping them out of private or unhelpful paths (like dashboards or APIs), preventing crawl budget waste.
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: ['/dashboard/', '/claim/', '/api/'], // Protect private routes from crawling
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next'
+
+// SEO Rationale: Providing a dynamic sitemap helps search engine crawlers discover and index public pages efficiently.
+// It prioritizes critical landing pages while omitting private routes that shouldn't be indexed.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: `${baseUrl}`,
+      changeFrequency: 'weekly',
+      priority: 1, // High priority for homepage
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8, // Secondary priority for auth pages
+    },
+  ]
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test'
+import sitemap from '../app/sitemap'
+import robots from '../app/robots'
+
+test.describe('SEO Metadata Generators', () => {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  test('sitemap() returns correct structure', () => {
+    const sitemapResult = sitemap()
+
+    expect(Array.isArray(sitemapResult)).toBe(true)
+    expect(sitemapResult).toHaveLength(2)
+
+    // Homepage
+    expect(sitemapResult[0]).toMatchObject({
+      url: baseUrl,
+      changeFrequency: 'weekly',
+      priority: 1,
+    })
+
+    // Login page
+    expect(sitemapResult[1]).toMatchObject({
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    })
+  })
+
+  test('robots() returns correct structure', () => {
+    const robotsResult = robots()
+
+    expect(robotsResult).toMatchObject({
+      rules: {
+        userAgent: '*',
+        allow: ['/', '/login'],
+        disallow: ['/dashboard/', '/claim/', '/api/'],
+      },
+      sitemap: `${baseUrl}/sitemap.xml`,
+    })
+  })
+})


### PR DESCRIPTION
💡 What
Added dynamic Next.js App Router metadata generators `app/sitemap.ts` and `app/robots.ts`. The sitemap exposes the public landing pages (`/` and `/login`) with priority, while the robots file prevents crawling of unhelpful private routes (`/dashboard/`, `/claim/`, `/api/`). Appropriate unit tests were also added for these handlers.

🎯 Why
By explicitly providing a `sitemap.xml`, we ensure search engines can efficiently discover and index our main entry points. By using `robots.txt` to block private/API areas, we conserve crawl budget and avoid messy, inaccessible indexes in search results. Using the built-in Next.js `MetadataRoute` functionality does this seamlessly at build/runtime without external dependencies.

📊 Impact
Improves search crawler discoverability for top-level pages, optimizes crawl budget efficiency, and improves site health diagnostics in Google Search Console. 

🔬 Verification
1. Run `pnpm test tests/seo.test.ts --config playwright-unit.config.ts` to confirm the generator payloads are structurally accurate.
2. Verified generators export the correct `MetadataRoute` structures omitting `lastModified: new Date()` as an anti-pattern.

🔗 References
- Next.js Metadata Route Handlers: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
- Google Search Central Crawl Budget Guide: https://developers.google.com/search/docs/crawling-indexing/large-site-managing-crawl-budget

---
*PR created automatically by Jules for task [9891605841021111051](https://jules.google.com/task/9891605841021111051) started by @mvng*