### PR TITLE
🎨 Palette: Add ARIA labels to note editing buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve accessibility of inline item note editing buttons
+**Learning:** Icon-only action buttons (like Check/Save or X/Cancel) used for inline text editing forms (e.g., editing notes in `PackingListSection`) often lack proper ARIA labels and focus visibility states, making them difficult to use for screen reader and keyboard-only users.
+**Action:** Always ensure that dynamically rendered, icon-only inline action buttons include descriptive `aria-label` attributes and explicit focus ring utility classes (like `focus:ring-2` and `focus-visible:ring-offset-1`) for robust keyboard and screen-reader accessibility.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -721,13 +721,14 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                   />
                   <div className="flex flex-col gap-1">
                     <button
+                      aria-label="Save note"
                       onClick={() => {
                         handleUpdateNotes(item.id, item.categoryId, item.packingListId, editingNotes?.notes || "")
                         setEditingNotes(null)
                       }}
-                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button aria-label="Cancel editing note" onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1"><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -1237,13 +1238,14 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                         />
                                         <div className="flex flex-col gap-1">
                                           <button
+                                            aria-label="Save note"
                                             onClick={() => {
                                               handleUpdateNotes(item.id, category.id, list.id, editingNotes?.notes || "")
                                               setEditingNotes(null)
                                             }}
-                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
                                           ><Check className="w-3 h-3" /></button>
-                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                                          <button aria-label="Cancel editing note" onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1"><X className="w-3 h-3" /></button>
                                         </div>
                                       </div>
                                     ) : item.notes ? (

--- a/tests/verify_ui.test.ts
+++ b/tests/verify_ui.test.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+test('Verify Save and Cancel Note Buttons', async ({ page }) => {
+  // We use page.setContent to render a basic isolated component test
+  // to avoid backend connection issues with complex flows locally.
+  const htmlContent = `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <script src="https://cdn.tailwindcss.com"></script>
+      <style>
+        /* Add focus visible styles to ensure we can see them in screenshots */
+        *:focus-visible { outline: 2px solid blue !important; }
+      </style>
+    </head>
+    <body class="p-8">
+      <div class="mt-1 flex items-start gap-1">
+        <textarea
+          class="text-xs p-1.5 w-64 border border-gray-200 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none"
+          rows="2"
+        >Buy toothpaste there...</textarea>
+        <div class="flex flex-col gap-1">
+          <!-- The Save button with our changes -->
+          <button
+            aria-label="Save note"
+            class="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3 h-3"><polyline points="20 6 9 17 4 12"></polyline></svg>
+          </button>
+
+          <!-- The Cancel button with our changes -->
+          <button
+            aria-label="Cancel editing note"
+            class="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-3 h-3"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+          </button>
+        </div>
+      </div>
+    </body>
+    </html>
+  `;
+
+  await page.setContent(htmlContent);
+  await page.waitForTimeout(1000);
+
+  // Take baseline screenshot
+  await page.screenshot({ path: '/home/jules/verification/screenshots/verification-baseline.png' });
+
+  // Focus Save button and screenshot
+  await page.keyboard.press('Tab'); // Should focus textarea
+  await page.keyboard.press('Tab'); // Should focus Save button
+  await page.waitForTimeout(500);
+  await page.screenshot({ path: '/home/jules/verification/screenshots/verification-save-focus.png' });
+
+  // Focus Cancel button and screenshot
+  await page.keyboard.press('Tab'); // Should focus Cancel button
+  await page.waitForTimeout(500);
+  await page.screenshot({ path: '/home/jules/verification/screenshots/verification-cancel-focus.png' });
+});


### PR DESCRIPTION
💡 **What:**
Added `aria-label` attributes and visible focus states (Tailwind `focus:ring-2`, `focus:ring-offset-1`) to the Check (Save) and X (Cancel) buttons used for inline note editing within the `PackingListSection` component.

🎯 **Why:**
These buttons only contained icons (Check and X), providing zero context to screen reader users about their function. Furthermore, they lacked focus indicators, making it impossible for keyboard-only users to see when they had tabbed to these actions while editing a note.

📸 **Before/After:**
Before: Buttons had no labels or focus styles.
After: Buttons clearly announce "Save note" / "Cancel editing note" and show a clear blue/gray focus ring when tabbed to.

♿ **Accessibility:**
- Added `aria-label="Save note"` and `aria-label="Cancel editing note"` to clarify function.
- Added `focus:outline-none focus:ring-2 focus:ring-blue-500/gray-500 focus:ring-offset-1` to improve visual keyboard tracking.

---
*PR created automatically by Jules for task [4186379621155135137](https://jules.google.com/task/4186379621155135137) started by @mvng*