### PR TITLE
🔍 Scout: Add sitemap.xml and robots.txt generation

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-04-09 - Adding sitemap and robots.ts
+**Learning:** Next.js MetadataRoute type handles robots.txt dynamically but doesn't mandate rationale comments, which are essential for long-term SEO maintenance.
+**Action:** Always include inline comments explaining the SEO rationale (e.g., why a route is blocked or why priority is set to a certain value) when creating or modifying sitemaps and robots.txt.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,19 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  // Use absolute URL for the sitemap reference as required by SEO best practices
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return {
+    rules: {
+      // Allow all crawlers by default
+      userAgent: '*',
+      // Explicitly allow root paths
+      allow: '/',
+      // Prevent crawlers from indexing private, authenticated user routes to optimize crawl budget
+      disallow: ['/dashboard/', '/settings/', '/inventory/', '/luggage/'],
+    },
+    // Direct crawlers to the sitemap for better indexation of allowed routes
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,21 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Ensure we always have an absolute URL for crawlers, falling back to prod if env is missing
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      // The homepage is the primary entry point for discovery and should be crawled most frequently
+      url: baseUrl,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      // The login page is public but changes less frequently and is slightly lower priority than the homepage
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+import sitemap from '../app/sitemap'
+import robots from '../app/robots'
+
+test.describe('SEO Configuration Files', () => {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  test('sitemap() generates valid Sitemap', () => {
+    const sitemapData = sitemap()
+
+    expect(Array.isArray(sitemapData)).toBe(true)
+    expect(sitemapData.length).toBe(2)
+
+    // Verify root URL
+    expect(sitemapData[0]).toMatchObject({
+      url: baseUrl,
+      changeFrequency: 'weekly',
+      priority: 1,
+    })
+
+    // Verify login URL
+    expect(sitemapData[1]).toMatchObject({
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    })
+  })
+
+  test('robots() generates valid Robots', () => {
+    const robotsData = robots()
+
+    expect(robotsData.sitemap).toBe(`${baseUrl}/sitemap.xml`)
+
+    // Ensure the rules are generated properly and handle Array or object
+    const rules = Array.isArray(robotsData.rules) ? robotsData.rules[0] : robotsData.rules
+    expect(rules).toBeDefined()
+    expect(rules.userAgent).toBe('*')
+    expect(rules.allow).toBe('/')
+    expect(rules.disallow).toContain('/dashboard/')
+    expect(rules.disallow).toContain('/settings/')
+    expect(rules.disallow).toContain('/inventory/')
+    expect(rules.disallow).toContain('/luggage/')
+  })
+})


### PR DESCRIPTION
💡 **What:**
Added `app/sitemap.ts` and `app/robots.ts` using the Next.js `MetadataRoute` API to dynamically generate `sitemap.xml` and `robots.txt`. Created unit tests to verify the dynamic URL outputs.

🎯 **Why:**
The application lacked clear crawlability directives. Adding a sitemap helps search engines discover the public pages (`/` and `/login`), while `robots.txt` explicitly blocks private user directories (`/dashboard/`, `/settings/`, `/inventory/`, `/luggage/`) to optimize the search engine crawl budget and prevent accidental indexing of gated content.

📊 **Impact:**
Improves indexation for public landing pages while explicitly restricting search engines from attempting to crawl protected paths.

🔬 **Verification:**
Ran `pnpm lint` and `pnpm exec playwright test tests/seo.test.ts --config playwright-unit.config.ts`. Verified the raw configuration objects locally.

🔗 **References:**
- Next.js Metadata Files: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
- Google Search Central - Robots.txt Intro: https://developers.google.com/search/docs/crawling-indexing/robots/intro

---
*PR created automatically by Jules for task [153910582188059699](https://jules.google.com/task/153910582188059699) started by @mvng*