### PR TITLE
⚡ Bolt: Memoize trip data for shared views

### DIFF
--- a/app/trip/[id]/TripPageClient.tsx
+++ b/app/trip/[id]/TripPageClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useTransition, useEffect } from 'react'
+import { useState, useTransition, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { getSharedTripById } from '@/actions/trip.actions'
@@ -92,26 +92,36 @@ export default function TripPageClient({ initialTrip, user, isOwner, initialTrip
   }
 
   const isSharedView = !isOwner
-  const displayTrip = isSharedView ? {
-    ...trip,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    packingLists: trip.packingLists.map((list: any) => ({
-      ...list,
+  const { displayTrip, allItems, totalItems, packedItems, progress } = useMemo(() => {
+    const computedDisplayTrip = isSharedView ? {
+      ...trip,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      categories: list.categories.map((cat: any) => ({
-        ...cat,
+      packingLists: trip.packingLists.map((list: any) => ({
+        ...list,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        items: cat.items.map((item: any) => ({ ...item, isPacked: false }))
+        categories: list.categories.map((cat: any) => ({
+          ...cat,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          items: cat.items.map((item: any) => ({ ...item, isPacked: false }))
+        }))
       }))
-    }))
-  } : trip
+    } : trip;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const allItems = displayTrip.packingLists.flatMap((list: any) => list.categories.flatMap((cat: any) => cat.items))
-  const totalItems = allItems.length
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const packedItems = allItems.filter((item: any) => item.isPacked).length
-  const progress = totalItems > 0 ? Math.round((packedItems / totalItems) * 100) : 0
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const computedAllItems = computedDisplayTrip.packingLists.flatMap((list: any) => list.categories.flatMap((cat: any) => cat.items));
+    const computedTotalItems = computedAllItems.length;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const computedPackedItems = computedAllItems.filter((item: any) => item.isPacked).length;
+    const computedProgress = computedTotalItems > 0 ? Math.round((computedPackedItems / computedTotalItems) * 100) : 0;
+
+    return {
+      displayTrip: computedDisplayTrip,
+      allItems: computedAllItems,
+      totalItems: computedTotalItems,
+      packedItems: computedPackedItems,
+      progress: computedProgress
+    };
+  }, [trip, isSharedView]);
 
   // Post-trip: true if end date is in the past
   const isTripOver = trip.endDate ? new Date(trip.endDate) < new Date() : false


### PR DESCRIPTION
💡 What
We are wrapping the `displayTrip` nested object modifications (which spread trip data and override all inner categories and items to mark them as `isPacked: false`) and its dependent aggregations (`allItems`, `totalItems`, `packedItems`, `progress`) inside a `useMemo` hook in the `TripPageClient` component.

🎯 Why
Because `displayTrip` uses a spread operator inside `.map()` functions up to 3 arrays deep to set `isPacked: false`, it recalculates on every render and produces entirely new references, which also forces the downstream `.flatMap()` derivations to recalculate. This generates unnecessary O(N) operations across potentially hundreds of items during fast re-renders (like user typing or optimistic UI updates). Memoizing the transformation drastically cuts down JavaScript execution overhead during render cycles.

📊 Impact
Prevents creating new array/object references and calculating array aggregations unnecessarily on every render for shared trip views, making UI interactions significantly snappier.

🔬 Measurement
Reviewing the React DevTools profiler while triggering component re-renders (e.g. typing notes, triggering UI popups) on a large shared trip will show decreased render time overhead since the flatMaps and spreads are no longer executing.

---
*PR created automatically by Jules for task [15822754760845983056](https://jules.google.com/task/15822754760845983056) started by @mvng*