### PR TITLE
🎨 Palette: Improve TaskCard accessibility with native CSS states and ARIA labels

### DIFF
--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,21 +20,19 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`relative p-4 rounded-xl border transition-all group ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? `Mark "${task.title}" as incomplete` : `Mark "${task.title}" as complete`}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,17 +67,19 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            aria-label={`Edit task "${task.title}"`}
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            aria-label={`Delete task "${task.title}"`}
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
           >
             <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
💡 **What**: Refactored `TaskCard` to remove React `isHovered` state, replacing it with CSS-based `group-hover:opacity-100` and `focus-within:opacity-100`. Added clear `aria-label` attributes to the status toggle, edit, and delete buttons. Added clear `focus-visible` styling (`focus-visible:ring-2`).

🎯 **Why**: Previously, the edit and delete buttons only appeared on mouse hover, making them completely invisible to keyboard-only users navigating via the `Tab` key. Furthermore, the icon-only buttons lacked context for screen readers. This change makes the actions natively accessible, visible upon keyboard focus, and more performant by removing unnecessary React re-renders on mouse movement.

📸 **Before/After**: See verification screenshots showing the action buttons becoming visible with a clear blue focus ring when focused via keyboard.

♿ **Accessibility**:
- Icon-only actions now have explicit `aria-label`s.
- Hidden actions now appear on `focus-within`.
- Improved focus indication with `focus-visible:ring-2`.

---
*PR created automatically by Jules for task [388562589001539607](https://jules.google.com/task/388562589001539607) started by @mvng*