### PR TITLE
🔍 Scout: Add sitemap and robots for search crawlability

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,22 @@
+import { MetadataRoute } from 'next'
+
+/**
+ * SEO Rationale:
+ * A robots.txt file is necessary to guide search engine crawlers, optimizing crawl budget.
+ * We explicitly allow crawling for public-facing routes (`/`, `/login`, shared `/trip/` pages).
+ * We aggressively block crawling for private, authenticated routes (e.g., `/dashboard`, `/settings`)
+ * to prevent search engines from attempting to index content that is inaccessible without a session,
+ * thereby focusing their crawling efforts on publicly valuable content.
+ */
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login', '/trip/'],
+      disallow: ['/dashboard/', '/settings/', '/inventory/', '/luggage/', '/claim/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { MetadataRoute } from 'next'
+
+/**
+ * SEO Rationale:
+ * A sitemap.xml file is crucial for search engine discoverability.
+ * By explicitly listing the application's public, static routes (`/`, `/login`),
+ * we ensure crawlers can efficiently find and index our primary entry points,
+ * leading to better visibility. We avoid using `lastModified: new Date()` as
+ * that is an anti-pattern that misleads crawlers for static pages.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test'
+import sitemap from '../app/sitemap'
+import robots from '../app/robots'
+
+test.describe('SEO Configuration', () => {
+  const expectedBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  test('sitemap.ts returns the correct static routes', () => {
+    const sitemapResult = sitemap()
+
+    expect(sitemapResult).toBeDefined()
+    expect(sitemapResult.length).toBe(2)
+
+    expect(sitemapResult).toContainEqual({
+      url: `${expectedBaseUrl}/`,
+      changeFrequency: 'weekly',
+      priority: 1,
+    })
+
+    expect(sitemapResult).toContainEqual({
+      url: `${expectedBaseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    })
+  })
+
+  test('robots.ts returns the correct rules and sitemap URL', () => {
+    const robotsResult = robots()
+
+    expect(robotsResult).toBeDefined()
+    expect(robotsResult.sitemap).toBe(`${expectedBaseUrl}/sitemap.xml`)
+
+    // In robots.ts rules can be a single object or an array. In our implementation it's a single object.
+    const rules = Array.isArray(robotsResult.rules) ? robotsResult.rules[0] : robotsResult.rules
+
+    expect(rules).toBeDefined()
+    expect(rules?.userAgent).toBe('*')
+    expect(rules?.allow).toEqual(['/', '/login', '/trip/'])
+    expect(rules?.disallow).toEqual(['/dashboard/', '/settings/', '/inventory/', '/luggage/', '/claim/'])
+  })
+})


### PR DESCRIPTION
💡 **What:** Added `app/sitemap.ts` and `app/robots.ts` using Next.js App Router's native `MetadataRoute` features.

🎯 **Why:** To improve search engine visibility by providing crawlers with a clear map of public pages (`/`, `/login`) and explicitly blocking them from indexing private, authenticated application routes (`/dashboard`, `/settings`, etc.). This optimizes crawl budget and prevents broken access errors for bots.

📊 **Impact:** Ensures crawlers correctly index landing pages while preventing them from indexing user-specific data. It uses dynamic environment variable fallbacks to work across all deployments (preview, production).

🔬 **Verification:** 
- Run `pnpm test tests/seo.test.ts` to confirm unit tests pass.
- Once deployed, visit `/sitemap.xml` and `/robots.txt` to verify proper rendering.
- Can be validated via Google Search Console.

🔗 **References:** 
- Next.js Metadata Files Docs: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
- Next.js Metadata Files Docs: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots

---
*PR created automatically by Jules for task [14899487875973722999](https://jules.google.com/task/14899487875973722999) started by @mvng*