### PR TITLE
🎨 Palette: Add accessible labels and focus states to TaskCard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Fix accessible buttons in hover-revealed containers (TaskCard)
+**Learning:** Found a pattern where action buttons (like Edit/Delete on `TaskCard`) were hidden unless the parent container was hovered (`isHovered ? 'opacity-100' : 'opacity-0'`), which completely breaks keyboard navigability because the buttons cannot be seen when focused.
+**Action:** Always ensure that containers with hover-revealed children also use `focus-within:opacity-100` so that keyboard users tab-navigating through the components will reveal the actions as they receive focus. Additionally, ensure all such actions have descriptive `aria-label`s and clear `focus-visible:ring-2` styles.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -35,9 +35,10 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full transition-colors ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
+          aria-label={isDone ? `Mark task ${task.title} as pending` : `Mark task ${task.title} as done`}
         >
           {isDone ? <CheckCircle className="w-5 h-5" /> : <Circle className="w-5 h-5" />}
         </button>
@@ -70,18 +71,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className={`flex items-center gap-1 transition-opacity focus-within:opacity-100 ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md hover:bg-blue-50 transition-colors"
             title="Edit task"
+            aria-label={`Edit task ${task.title}`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-md hover:bg-red-50 transition-colors"
             title="Delete task"
+            aria-label={`Delete task ${task.title}`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
💡 What: Added `aria-label`s, `focus-visible:ring-2` styles to action buttons, and `focus-within:opacity-100` to the hover container within `TaskCard.tsx`.
🎯 Why: The task action buttons (Edit, Delete, Toggle) lacked descriptive labels for screen readers. Furthermore, the Edit and Delete buttons were completely invisible to keyboard-only users because their visibility relied entirely on pointer `hover` events.
📸 Before/After: Screenshots were taken in Playwright highlighting the visible focus ring for keyboard navigation.
♿ Accessibility:
- Added context-aware `aria-label`s to Edit, Delete, and Toggle status buttons.
- Ensured keyboard visibility for hover-revealed containers using `focus-within:opacity-100`.
- Provided explicit visual focus cues using `focus-visible:ring-2`.

---
*PR created automatically by Jules for task [15308009845757313558](https://jules.google.com/task/15308009845757313558) started by @mvng*