### PR TITLE
🎨 Palette: Add focus-within styles to dashboard action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+
+## 2024-05-18 - Ensure keyboard accessibility for hover-revealed containers
+**Learning:** When using Tailwind CSS `group-hover` to reveal action buttons on hover (e.g., `opacity-0 group-hover:opacity-100`), keyboard users won't see the buttons when they tab into them unless the container also responds to focus.
+**Action:** Always include `focus-within:opacity-100` alongside `group-hover:opacity-100` on containers that hide interactive elements until hovered, ensuring they become visible during keyboard navigation.

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -157,7 +157,7 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 flex gap-1 transition-opacity">
+      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-1 transition-opacity">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
           className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center"
@@ -200,7 +200,7 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
+      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
           className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center"


### PR DESCRIPTION
💡 **What**: Added `focus-within:opacity-100` to the action button containers in `app/dashboard/DashboardClient.tsx`.
🎯 **Why**: Previously, the edit and delete buttons on trip cards were only visible on pointer hover (`group-hover:opacity-100`). Keyboard users tabbing through the interface could focus the buttons, but the container remained invisible (`opacity-0`), making it impossible to see which action was currently focused.
📸 **Before/After**: See verification media in the pre-commit checks.
♿ **Accessibility**: Ensures critical trip management actions are visible and operable for users relying on keyboard navigation, complying with basic WCAG focus visibility standards.

---
*PR created automatically by Jules for task [8795500770766463764](https://jules.google.com/task/8795500770766463764) started by @mvng*