### PR TITLE
⚡ Bolt: Memoize packing list generation in new trip form

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+## 2025-04-18 - Controlled inputs in form components
+**Learning:** In Next.js client components using controlled inputs for text fields (e.g., `value={formData.name}`), the component re-renders on every keystroke. If expensive calculations (like generating a default packing list layout or performing `.reduce` over large arrays) are present in the render body, it causes severe input lag.
+**Action:** Always wrap expensive synchronous generation or reduction logic in `useMemo`, ensuring its dependency array only includes the variables that actually dictate the output (e.g., dates, trip type) rather than the frequently changing text inputs.

--- a/app/dashboard/new/page.tsx
+++ b/app/dashboard/new/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createTrip } from '@/actions/trip.actions'
@@ -117,11 +117,23 @@ export default function NewTripPage() {
     }
   }
 
-  const duration = getDurationDays(formData.startDate, formData.endDate)
-  const templateCategories = formData.generateSuggestions
-    ? generatePackingList(formData.tripType as "leisure" | "business" | "beach" | "hiking" | "city" | "skiing", duration, formData.transportMode)
-    : []
-  const totalItems = templateCategories.reduce((sum, c) => sum + c.items.length, 0)
+  const { templateCategories, totalItems, duration } = useMemo(() => {
+    // ⚡ Bolt Performance Optimization
+    // Why: `generatePackingList` and `.reduce` were running on every render cycle (e.g. on every keystroke in the form inputs).
+    // Impact: Prevents expensive object creation, array mapping, and reduction when unrelated state like `name` or `destination` changes.
+    const duration = getDurationDays(formData.startDate, formData.endDate)
+    const templateCategories = formData.generateSuggestions
+      ? generatePackingList(formData.tripType as "leisure" | "business" | "beach" | "hiking" | "city" | "skiing", duration, formData.transportMode)
+      : []
+    const totalItems = templateCategories.reduce((sum, c) => sum + c.items.length, 0)
+    return { templateCategories, totalItems, duration }
+  }, [
+    formData.startDate,
+    formData.endDate,
+    formData.generateSuggestions,
+    formData.tripType,
+    formData.transportMode
+  ])
 
   return (
     <div className="min-h-screen bg-gray-50 py-12">


### PR DESCRIPTION
💡 **What**
Wrapped the `duration`, `templateCategories`, and `totalItems` generation logic in a `useMemo` hook inside the `app/dashboard/new/page.tsx` component.

🎯 **Why**
The "New Trip" form uses controlled state (`formData`) for its text inputs like `name` and `destination`. As a result, typing in these fields triggered a re-render of the entire component on every keystroke. Because the packing list generator and array `.reduce()` were executed on every render cycle, this caused unnecessary CPU overhead and input lag, making the form feel sluggish.

📊 **Impact**
Prevents `O(N)` object creation, mapping, and reduction on every keystroke. This drastically reduces React render times when users are simply typing out their trip name or destination, resulting in a significantly more responsive UI. 

🔬 **Measurement**
1. Navigate to `/dashboard/new`.
2. Type rapidly in the "Trip Name" or "Destination" field.
3. Observe that text entry is instant, without jank or lag, because the packing list is no longer being regenerated on each keystroke.

---
*PR created automatically by Jules for task [9860724236956768914](https://jules.google.com/task/9860724236956768914) started by @mvng*