### PR TITLE
🔍 Scout: Add robots.txt and sitemap.xml generation for crawlability

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-05-28 - Safely concatenating dynamic Base URLs
+**Learning:** When using `process.env.NEXT_PUBLIC_APP_URL` to dynamically generate URLs in Next.js metadata routes (like `sitemap.ts` and `robots.ts`), there is a risk of generating malformed URLs (e.g., `https://example.com//sitemap.xml`) if the environment variable unexpectedly includes a trailing slash.
+**Action:** Always check and strip trailing slashes from environment-provided base URLs (e.g., `const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl`) before using them in string interpolation to ensure robust URL construction across different deployment environments.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,29 @@
+import { MetadataRoute } from 'next';
+
+/**
+ * SEO Rationale:
+ * A robots.txt file is essential for guiding search engine crawlers on which pages to index.
+ * We allow crawling of the root/public pages while explicitly disallowing private,
+ * authenticated routes (like dashboard, settings, etc.) to prevent sensitive content
+ * from being indexed and to optimize crawl budget.
+ */
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+  // Ensure the baseUrl doesn't end with a slash to avoid double slashes when concatenating
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/dashboard',
+        '/settings',
+        '/inventory',
+        '/luggage',
+        '/claim/',
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,27 @@
+import { MetadataRoute } from 'next';
+
+/**
+ * SEO Rationale:
+ * An XML sitemap helps search engines discover and index public pages more efficiently.
+ * Here we list our primary public static routes (`/` and `/login`) with their respective priorities.
+ * We avoid using `lastModified: new Date()` as an anti-pattern for static routes,
+ * which falsely tells search engines the content has changed on every request.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+  // Ensure the baseUrl doesn't end with a slash to avoid double slashes when concatenating
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+  return [
+    {
+      url: baseUrl,
+      changeFrequency: 'yearly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    },
+  ];
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import robots from '../app/robots';
+import sitemap from '../app/sitemap';
+
+test.describe('SEO Metadata', () => {
+  test('robots.ts should disallow private routes and provide sitemap URL', () => {
+    const robotsMetadata = robots();
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+
+    expect(robotsMetadata.sitemap).toBe(`${baseUrl}/sitemap.xml`);
+
+    const rules = Array.isArray(robotsMetadata.rules) ? robotsMetadata.rules[0] : robotsMetadata.rules;
+    expect(rules.userAgent).toBe('*');
+    expect(rules.allow).toBe('/');
+    expect(rules.disallow).toEqual(
+      expect.arrayContaining([
+        '/dashboard',
+        '/settings',
+        '/inventory',
+        '/luggage',
+        '/claim/',
+      ])
+    );
+  });
+
+  test('sitemap.ts should return static public routes without lastModified', () => {
+    const sitemapMetadata = sitemap();
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+
+    expect(sitemapMetadata).toHaveLength(2);
+
+    expect(sitemapMetadata).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ url: baseUrl }),
+        expect.objectContaining({ url: `${baseUrl}/login` }),
+      ])
+    );
+
+    // Verify none of the items have lastModified
+    sitemapMetadata.forEach(item => {
+      expect(item.lastModified).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
💡 What: Implemented `app/robots.ts` and `app/sitemap.ts` to expose static routes (`/`, `/login`) and disallow crawling on private application routes.
🎯 Why: Without these files, search engines may inefficiently crawl private routes (wasting crawl budget) or miss indexing critical public landing pages.
📊 Impact: Ensures sensitive routes remain out of search indices and accelerates discovery of public pages.
🔬 Verification: Run `pnpm test` to verify `seo.test.ts` or navigate to `/robots.txt` and `/sitemap.xml` on deploy.
🔗 References: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots

---
*PR created automatically by Jules for task [8662266696687383691](https://jules.google.com/task/8662266696687383691) started by @mvng*