### PR TITLE
🎨 Palette: Add keyboard accessibility to TaskCard and TaskForm

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Fix hidden action buttons on keyboard focus in Task cards
+**Learning:** Found an accessibility anti-pattern in `TaskCard.tsx` where secondary action buttons (Edit/Delete) were hidden using `opacity-0` and only revealed on pointer hover (`opacity-100`). This made them completely inaccessible to keyboard users because tabbing into the buttons didn't make them visible.
+**Action:** When hiding action containers until interaction, always pair `opacity-0` with `focus-within:opacity-100` alongside existing hover states, ensuring keyboard focus makes the actions visible. Also, ensure the individual buttons have `focus-visible:ring-2` to clearly indicate focus once revealed.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -35,9 +35,10 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
+          aria-label={isDone ? 'Mark as incomplete' : 'Mark as complete'}
         >
           {isDone ? <CheckCircle className="w-5 h-5" /> : <Circle className="w-5 h-5" />}
         </button>
@@ -70,18 +71,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className={`flex items-center gap-1 transition-opacity focus-within:opacity-100 ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
+            aria-label="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
+            aria-label="Delete task"
           >
             <Trash2 className="w-4 h-4" />
           </button>

--- a/components/TripPlanningAssistant/TaskForm.tsx
+++ b/components/TripPlanningAssistant/TaskForm.tsx
@@ -73,7 +73,8 @@ export default function TaskForm({ initialTask, onSave, onCancel, startDate }: T
         <button
           type="button"
           onClick={onCancel}
-          className="p-1 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors"
+          className="p-1 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          aria-label="Close"
         >
           <X className="w-5 h-5" />
         </button>


### PR DESCRIPTION
💡 What: Added ARIA labels and keyboard focus states to icon-only buttons in `TaskCard.tsx` and `TaskForm.tsx`. Crucially, added `focus-within:opacity-100` to the task action container so the edit/delete buttons become visible when a keyboard user tabs into them (they were previously only visible on mouse hover).
🎯 Why: To ensure the task management interface is fully accessible to keyboard-only and screen reader users. Without these changes, keyboard users tabbed into invisible buttons and didn't know what they were focused on.
📸 Before/After: Action buttons now have clear blue/red focus rings, and the container reveals itself properly during tab navigation.
♿ Accessibility:
- Added `aria-label`s to Task status toggle, Task Edit, Task Delete, and TaskForm Close buttons.
- Added explicit `focus-visible:ring-2` to all icon-only buttons.
- Fixed hidden container issue with `focus-within:opacity-100`.

---
*PR created automatically by Jules for task [4179430634631338688](https://jules.google.com/task/4179430634631338688) started by @mvng*