### PR TITLE
🔍 Scout: Add sitemap and robots.txt generation

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage', '/claim/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // Omitting private routes and dynamic unlisted routes like /claim/[token]
+  return [
+    {
+      url: `${baseUrl}`,
+      changeFrequency: 'yearly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import sitemap from '../app/sitemap';
+import robots from '../app/robots';
+
+test.describe('SEO Metadata Functions', () => {
+  test('sitemap returns correct public routes without lastModified', () => {
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+    const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+    const result = sitemap();
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      url: `${baseUrl}`,
+      changeFrequency: 'yearly',
+      priority: 1,
+    });
+    expect(result[1]).toEqual({
+      url: `${baseUrl}/login`,
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    });
+    // Ensure no lastModified is present
+    expect(result[0].lastModified).toBeUndefined();
+  });
+
+  test('robots returns correct crawler rules and sitemap URL', () => {
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+    const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+    const result = robots();
+
+    expect(result.sitemap).toBe(`${baseUrl}/sitemap.xml`);
+
+    const rules = Array.isArray(result.rules) ? result.rules[0] : result.rules;
+    expect(rules?.userAgent).toBe('*');
+    expect(rules?.allow).toBe('/');
+    expect(rules?.disallow).toContain('/dashboard');
+    expect(rules?.disallow).toContain('/settings');
+    expect(rules?.disallow).toContain('/inventory');
+    expect(rules?.disallow).toContain('/luggage');
+    expect(rules?.disallow).toContain('/claim/');
+  });
+});


### PR DESCRIPTION
💡 **What:** Added dynamically generated `sitemap.xml` and `robots.txt` files using Next.js App Router conventions (`app/sitemap.ts` and `app/robots.ts`).
🎯 **Why:** To improve search engine crawlability by explicitly defining allowed/disallowed routes and providing a map of public pages, while ensuring private and unlisted dynamic routes (like `/dashboard` and `/claim/[token]`) are kept out of the search index.
📊 **Impact:** Improves organic search visibility by directing crawlers to key pages (like the homepage and login page) and preventing indexation bloat from private application state URLs.
🔬 **Verification:** Implemented `tests/seo.test.ts` to assert correct behavior, avoiding hardcoded fallback URLs to prevent brittle tests. Ran `pnpm lint` and `pnpm test` to confirm correctness.
🔗 **References:** [Next.js Metadata Files Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [15006533042006720769](https://jules.google.com/task/15006533042006720769) started by @mvng*