### PR TITLE
🎨 Palette: Add aria-labels to packing list icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2026-04-12 - Add accessible aria-labels to packing list note/delete buttons
+**Learning:** Found a pattern in `components/PackingListSection.tsx` where hover-revealed, icon-only buttons for interacting with individual packing items (e.g. Save/Cancel notes, Pack Last, Delete) were missing `aria-label` attributes. Without these attributes, screen reader users would only hear the generic element type rather than its purpose, making management of packing list items difficult.
+**Action:** When implementing repeating interactive list items with icon-only action buttons, always ensure that each button includes an explicit, descriptive `aria-label` attribute (using dynamic template literals when possible for better context) so that screen readers can accurately interpret their function.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -726,8 +726,9 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         setEditingNotes(null)
                       }}
                       className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      aria-label="Save note"
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200" aria-label="Cancel note"><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -748,6 +749,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
             <button
               onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
               title="Add/Edit Note"
+              aria-label={`Add or edit note for ${item.name}`}
               className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
             ><MessageSquare className="w-3.5 h-3.5" /></button>
             <button
@@ -1242,8 +1244,9 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                               setEditingNotes(null)
                                             }}
                                             className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                                            aria-label="Save note"
                                           ><Check className="w-3 h-3" /></button>
-                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200" aria-label="Cancel note"><X className="w-3 h-3" /></button>
                                         </div>
                                       </div>
                                     ) : item.notes ? (
@@ -1263,14 +1266,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                   <button
                                     onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
                                     title="Add/Edit Note"
+                                    aria-label={`Add or edit note for ${item.name}`}
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
                                   ><MessageSquare className="w-3.5 h-3.5" /></button>
                                   <button
                                     onClick={() => handleTogglePackLast(item.id, category.id, list.id, item.packLast)}
                                     title="Add to departure checklist"
+                                    aria-label={item.packLast ? 'Remove from pack last' : 'Mark as pack last'}
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center"
                                   ><Sunrise className="w-3.5 h-3.5" /></button>
-                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
+                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} aria-label={`Remove ${item.name} from packing list`} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
                                 </div>
                               )}
                             </li>


### PR DESCRIPTION
💡 What: Added descriptive `aria-label` attributes to the icon-only action buttons (Add/Edit Note, Save note, Cancel note, Add to departure checklist, Remove item) inside `components/PackingListSection.tsx`.

🎯 Why: These buttons appear on hover and only use icons (like a checkmark, X, or message bubble). Screen readers rely on text alternatives for non-text content, so adding `aria-label` attributes ensures keyboard and screen reader users understand what each button does when navigating through the packing list items.

📸 Before/After: Visuals are unchanged.

♿ Accessibility: Ensures that screen reader users are provided with clear context for actions, making the core packing list functionally accessible.

---
*PR created automatically by Jules for task [15983771106169498761](https://jules.google.com/task/15983771106169498761) started by @mvng*