### PR TITLE
⚡ Bolt: Memoize packing list generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2025-04-13 - UI Lag from Unmemoized Array Operations
+**Learning:** Controlled text inputs in complex React forms (like `NewTripPage` trip creation) cause frequent re-renders on every keystroke. In this codebase, if operations like `generatePackingList` and subsequent array `.reduce()` calculations are executed inline within the component body without memoization, they execute synchronously on every keystroke. This causes noticeable UI lag for users when typing the trip name or destination.
+**Action:** Always wrap computationally expensive operations—especially those involving deep array mapping, reduction, or instantiation (like `generatePackingList`)—in `useMemo` hooks, ensuring the dependency array is correctly tailored to only the values that actually influence the calculation.

--- a/app/dashboard/new/page.tsx
+++ b/app/dashboard/new/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createTrip } from '@/actions/trip.actions'
@@ -117,11 +117,31 @@ export default function NewTripPage() {
     }
   }
 
-  const duration = getDurationDays(formData.startDate, formData.endDate)
-  const templateCategories = formData.generateSuggestions
-    ? generatePackingList(formData.tripType as "leisure" | "business" | "beach" | "hiking" | "city" | "skiing", duration, formData.transportMode)
-    : []
-  const totalItems = templateCategories.reduce((sum, c) => sum + c.items.length, 0)
+  // ⚡ Bolt: Memoize expensive template generation to prevent UI lag
+  // on every keystroke when typing in the destination/name fields.
+  const { templateCategories, duration, totalItems } = useMemo(() => {
+    const durationDays = getDurationDays(formData.startDate, formData.endDate)
+    const categories = formData.generateSuggestions
+      ? generatePackingList(
+          formData.tripType as "leisure" | "business" | "beach" | "hiking" | "city" | "skiing",
+          durationDays,
+          formData.transportMode
+        )
+      : []
+    const itemsCount = categories.reduce((sum, c) => sum + c.items.length, 0)
+
+    return {
+      templateCategories: categories,
+      duration: durationDays,
+      totalItems: itemsCount
+    }
+  }, [
+    formData.startDate,
+    formData.endDate,
+    formData.generateSuggestions,
+    formData.tripType,
+    formData.transportMode
+  ])
 
   return (
     <div className="min-h-screen bg-gray-50 py-12">


### PR DESCRIPTION
💡 **What**:
Wrapped the `generatePackingList` and `totalItems` `.reduce()` calculations in a `useMemo` hook inside `app/dashboard/new/page.tsx`.

🎯 **Why**: 
The `NewTripPage` form utilizes controlled inputs. As users typed into fields like "Destination", state updates caused the component to re-render entirely, executing `generatePackingList` and reducing the resulting arrays on the main thread for every keystroke. This synchronous blocking operation led to noticeable UI lag. 

📊 **Impact**: 
Improves form responsiveness significantly. `generatePackingList` now only re-runs when its specific dependencies (trip dates, transport mode, trip type, or the generation toggle) change, entirely eliminating the input lag when typing the trip name or destination.

🔬 **Measurement**: 
1. Run `pnpm dev`.
2. Navigate to `/dashboard/new`.
3. Try typing in the "Destination" field. The keystrokes should register immediately without lag, unlike before where the calculation blocked the main thread.

---
*PR created automatically by Jules for task [3445468547035977180](https://jules.google.com/task/3445468547035977180) started by @mvng*