### PR TITLE
🔍 Scout: Add sitemap and robots for better crawlability

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,19 @@
+import { MetadataRoute } from 'next';
+
+// SEO Rationale: A dynamically generated robots.txt file controls crawler access and prevents
+// search engines from indexing private, authenticated, or sensitive routes (like /dashboard or /settings).
+// This preserves the "crawl budget" for valuable public-facing content.
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      // Prevent crawlers from accessing private or dynamic application state routes
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage', '/claim/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`, // Point crawlers to the dynamically generated sitemap
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next';
+
+// SEO Rationale: A dynamic sitemap.xml helps search engines (like Google) discover and index the most important
+// static pages more efficiently. It signals which pages are core to the application.
+// We include '/' (landing page) and '/login' to ensure maximum visibility for user acquisition.
+// Private dynamic routes are deliberately excluded to prevent crawler noise.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      changeFrequency: 'weekly',
+      priority: 1, // Homepage gets highest priority
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    },
+  ];
+}

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+import sitemap from '../app/sitemap';
+import robots from '../app/robots';
+
+test('sitemap generates correctly', async () => {
+  const result = sitemap();
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+  expect(result.length).toBe(2);
+  expect(result[0].url).toBe(`${baseUrl}/`);
+  expect(result[1].url).toBe(`${baseUrl}/login`);
+});
+
+test('robots generates correctly', async () => {
+  const result = robots();
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+  const rules = Array.isArray(result.rules) ? result.rules[0] : result.rules;
+
+  expect(rules?.allow).toContain('/');
+  expect(rules?.disallow).toContain('/dashboard');
+  expect(rules?.disallow).toContain('/settings');
+  expect(rules?.disallow).toContain('/inventory');
+  expect(rules?.disallow).toContain('/luggage');
+  expect(rules?.disallow).toContain('/claim/');
+  expect(result.sitemap).toBe(`${baseUrl}/sitemap.xml`);
+});


### PR DESCRIPTION
💡 **What:**
Added dynamic generation for `sitemap.xml` via `app/sitemap.ts` and crawler control via `app/robots.ts` using Next.js Metadata Route APIs.

🎯 **Why:**
To improve the crawlability of the application. The sitemap helps search engines discover the public landing and login pages efficiently, while the robots.txt explicitly disallows crawling of private authenticated routes (`/dashboard`, `/settings`, etc.), preserving the application's "crawl budget" for valuable pages.

📊 **Impact:**
Enables better indexing for the main pages and stops search engines from wasting resources indexing stateful or protected routes, directly impacting search visibility.

🔬 **Verification:**
- Validated via `tests/sitemap.test.ts` to ensure routes are output correctly.
- Can be manually confirmed by accessing `/sitemap.xml` and `/robots.txt` paths when the app is running.

🔗 **References:**
- https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
- https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots

---
*PR created automatically by Jules for task [3840056013875416183](https://jules.google.com/task/3840056013875416183) started by @mvng*