### PR TITLE
🔧 Fix: Improve accessibility of trip member inline action buttons

### DIFF
--- a/.jules/felix.md
+++ b/.jules/felix.md
@@ -1,0 +1,3 @@
+## 2026-04-14 - TripMembersSection accessibility buttons
+**Learning:** Icon-only action buttons without labels or focus outlines are not fully accessible to keyboard or screen reader users. Hover states aren't sufficient.
+**Action:** When fixing or creating UI elements with icon buttons, ensure appropriate `aria-label` and `focus-visible:ring-2` utilities are used.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -59,9 +59,10 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
               className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
-                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
+                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1' : 'cursor-default focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1'
               }`}
-              title={member.name}
+              title={isOwner ? `Remove ${member.name}` : member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
               <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
               {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
@@ -84,8 +85,9 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
             title="Add member"
+            aria-label="Add new member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -110,15 +112,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
             title="Confirm"
+            aria-label="Confirm new member"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-1"
             title="Cancel"
+            aria-label="Cancel adding member"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
🐛 Issue: #258
🔍 Root Cause: The inline action buttons in `TripMembersSection` lacked proper accessibility attributes and styling, making them difficult to use for keyboard navigators and screen readers. Specifically, they were missing `aria-label`s and visible focus outlines. The remove button `title` and `aria-label` incorrectly assumed the user had permission.
🛠️ Fix: Added `aria-label` attributes and explicit `focus-visible:ring-2` Tailwind utility classes to the icon-only buttons (Remove, Add, Confirm, Cancel). Updated the remove member button to conditionally show the "Remove [Name]" text or just the "[Name]" based on whether the user is the owner.
✅ Verification: Ran format and lint checks, and the full test suite (`pnpm test`). Visual verification via CSS classes confirms focus rings are visible on keyboard navigation.
⚠️ Notes: These changes are visually localized and only improve standard accessibility behavior without modifying core logic.

---
*PR created automatically by Jules for task [12330095735328425777](https://jules.google.com/task/12330095735328425777) started by @mvng*