### PR TITLE
🔍 Scout: Add dynamic sitemap.xml to improve crawl efficiency

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-04-14 - [Dynamic Sitemap URLs]
+**Learning:** Hardcoding URLs in `app/sitemap.ts` or in assertions for its tests leads to brittle code across environments (e.g., local development versus production deployment). Using `process.env.NEXT_PUBLIC_APP_URL` with a dynamic fallback and calculating the `baseUrl` in tests avoids these issues and ensures robustness. Additionally, `lastModified: new Date()` is an anti-pattern for static routes as it inaccurately tells search engines the content changes on every request.
+**Action:** When implementing or testing `sitemap.ts` in Next.js, always use environment variables for base URLs with appropriate fallback logic, both in the implementation and the corresponding unit tests. Explicitly omit `lastModified` on static routes to prevent crawl efficiency issues.

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Generating a dynamic sitemap.xml ensures search engines can efficiently discover
+// all public-facing, indexable routes. This increases crawl efficiency.
+// We explicitly exclude authenticated routes (e.g., /dashboard, /inventory)
+// and dynamic private pages (e.g., /claim/[token]) to keep the crawl scope focused on landing pages.
+// We also avoid using lastModified: new Date() as it is an anti-pattern for static routes
+// that inaccurately tells crawlers content has updated on every single request.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+import sitemap from '../app/sitemap'
+
+test.describe('sitemap', () => {
+  test('returns the correct sitemap structure for public routes', () => {
+    // Determine the base URL dynamically just like the implementation does
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+    const expectedBaseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+    const result = sitemap()
+
+    expect(result).toHaveLength(2)
+
+    // Check root route
+    expect(result[0]).toEqual({
+      url: `${expectedBaseUrl}/`,
+      changeFrequency: 'weekly',
+      priority: 1,
+    })
+
+    // Check login route
+    expect(result[1]).toEqual({
+      url: `${expectedBaseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    })
+
+    // Explicitly verify lastModified is not present to adhere to SEO learnings
+    expect(result[0].lastModified).toBeUndefined()
+    expect(result[1].lastModified).toBeUndefined()
+  })
+})


### PR DESCRIPTION
💡 **What:** Added a dynamic `app/sitemap.ts` file that generates a `sitemap.xml` for core public routes (`/` and `/login`). Built an accompanying Playwright unit test.

🎯 **Why:** Search engines rely on sitemaps to efficiently discover and index pages. Previously, the application lacked a sitemap, which could lead to incomplete indexing or wasted crawl budget on private/authenticated routes. Furthermore, omitting `lastModified: new Date()` on static routes avoids the anti-pattern of falsely signaling continuous content changes.

📊 **Impact:** Increases crawl efficiency and ensures deterministic indexing of our critical landing pages while protecting the crawl budget by excluding unlisted dynamic routes and authenticated areas.

🔬 **Verification:**
1. Run `pnpm lint` to ensure code style is maintained.
2. Run `pnpm test tests/sitemap.test.ts` to confirm the sitemap structure and dynamic base URL fallback logic works correctly.

🔗 **References:** [Google Search Central: Build and submit a sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)

---
*PR created automatically by Jules for task [14209313542727706673](https://jules.google.com/task/14209313542727706673) started by @mvng*