### PR TITLE
🎨 Palette: Add accessible labels to inline edit and delete buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve accessibility of inline edit actions
+**Learning:** Discovered that icon-only action buttons generated within lists (specifically the Save/Cancel buttons for inline note editing and the Delete button in alternative view modes) lacked `aria-label`s and proper focus ring utilities, negatively impacting screen reader usage and keyboard accessibility.
+**Action:** When implementing or fixing inline edit components, ensure that conditionally rendered icon-only buttons always include descriptive `aria-label`s and focus ring utility classes (like `focus:ring-2`) so they are fully accessible.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -721,13 +721,14 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                   />
                   <div className="flex flex-col gap-1">
                     <button
+                      aria-label="Save note"
                       onClick={() => {
                         handleUpdateNotes(item.id, item.categoryId, item.packingListId, editingNotes?.notes || "")
                         setEditingNotes(null)
                       }}
-                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button aria-label="Cancel note edit" onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400"><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -1237,13 +1238,14 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                         />
                                         <div className="flex flex-col gap-1">
                                           <button
+                                            aria-label="Save note"
                                             onClick={() => {
                                               handleUpdateNotes(item.id, category.id, list.id, editingNotes?.notes || "")
                                               setEditingNotes(null)
                                             }}
-                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
                                           ><Check className="w-3 h-3" /></button>
-                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                                          <button aria-label="Cancel note edit" onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400"><X className="w-3 h-3" /></button>
                                         </div>
                                       </div>
                                     ) : item.notes ? (
@@ -1270,7 +1272,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                     title="Add to departure checklist"
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center"
                                   ><Sunrise className="w-3.5 h-3.5" /></button>
-                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
+                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center" aria-label={`Remove ${item.name} from packing list`} title="Remove from packing list"><X className="w-4 h-4" /></button>
                                 </div>
                               )}
                             </li>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label`s and keyboard focus utility rings to the icon-only Save/Cancel buttons used for editing notes inline, as well as the Delete button present when viewing list items grouped by Person/Luggage.
🎯 **Why:** Previously, these buttons were only identifiable visually via icons, making them invisible to screen readers and difficult to navigate via keyboard.
♿ **Accessibility:** This ensures all interactive elements within the packing list have proper labels for assistive technologies and clear visual focus rings for keyboard navigation.

---
*PR created automatically by Jules for task [18012866756319047327](https://jules.google.com/task/18012866756319047327) started by @mvng*