### PR TITLE
🎨 Palette: Enhance Trip Members Section Keyboard & Screen Reader Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Add accessible avatar tooltips and inline form actions
+**Learning:** Found that custom avatar group elements with hover-revealed tooltips (`group-hover:opacity-100`) and hover-revealed remove buttons (`group-hover:block`) lacked keyboard accessibility because they were only bound to mouse interactions. Also found inline form actions (like confirm/cancel) lacked distinct focus indicators.
+**Action:** Always complement `group-hover:*` visibility utilities with `group-focus-within:*` so keyboard users can navigate to inner elements and see tooltips/buttons. Add explicit `focus-visible:ring-*` styles and `aria-label`s to dynamically rendered interactive elements to ensure screen readers announce actions and keyboard navigation is visibly trackable.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus-visible:ring-blue-500 focus-visible:outline-none focus:outline-none ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,8 +85,9 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus:outline-none"
             title="Add member"
+            aria-label="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -110,15 +112,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus:outline-none focus-visible:ring-offset-1"
             title="Confirm"
+            aria-label="Confirm add member"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none focus:outline-none focus-visible:ring-offset-1"
             title="Cancel"
+            aria-label="Cancel add member"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
💡 What: Added keyboard focus indicators (`focus-visible:ring-*`), keyboard-accessible tooltips and "remove" actions (`group-focus-within:*`), and explicit `aria-label`s to the avatar buttons and inline form actions in the `TripMembersSection`.
🎯 Why: Previously, the "remove member" button and tooltip were only visible on mouse hover, making them undiscoverable to keyboard users. Icon-only buttons lacked ARIA labels, making them ambiguous for screen readers.
📸 Before/After: Verified visually via Playwright that tab focus correctly triggers the 'X' remove icon and tooltip display on avatars.
♿ Accessibility:
- Screen reader users now hear clear announcements (e.g., "Remove Alice") instead of empty button context.
- Keyboard users can tab to an avatar and see both the tooltip and the remove action.
- Clear blue/gray focus rings added to inline edit actions.

---
*PR created automatically by Jules for task [11098316608550349596](https://jules.google.com/task/11098316608550349596) started by @mvng*