### PR TITLE
⚡ Bolt: Memoize packing list generation in new trip form

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2023-10-27 - Controlled Input Re-renders
+**Learning:** In React client form components (e.g., trip creation in `app/dashboard/new/page.tsx`), controlled text inputs cause frequent re-renders on every keystroke.
+**Action:** Always wrap computationally expensive operations, such as `generatePackingList` or large array `.reduce()` calculations, in `useMemo` hooks to prevent UI lag.

--- a/app/dashboard/new/page.tsx
+++ b/app/dashboard/new/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createTrip } from '@/actions/trip.actions'
@@ -117,11 +117,17 @@ export default function NewTripPage() {
     }
   }
 
-  const duration = getDurationDays(formData.startDate, formData.endDate)
-  const templateCategories = formData.generateSuggestions
-    ? generatePackingList(formData.tripType as "leisure" | "business" | "beach" | "hiking" | "city" | "skiing", duration, formData.transportMode)
-    : []
-  const totalItems = templateCategories.reduce((sum, c) => sum + c.items.length, 0)
+  const { templateCategories, totalItems } = useMemo(() => {
+    // ⚡ Bolt Performance Optimization
+    // Why: Prevents expensive generatePackingList array instantiations and reducing operations on every keystroke
+    // Impact: Keeps the form input responsive (prevents UI lag) by only recalculating when trip parameters actually change
+    const duration = getDurationDays(formData.startDate, formData.endDate)
+    const categories = formData.generateSuggestions
+      ? generatePackingList(formData.tripType as "leisure" | "business" | "beach" | "hiking" | "city" | "skiing", duration, formData.transportMode)
+      : []
+    const total = categories.reduce((sum, c) => sum + c.items.length, 0)
+    return { templateCategories: categories, totalItems: total }
+  }, [formData.startDate, formData.endDate, formData.tripType, formData.transportMode, formData.generateSuggestions])
 
   return (
     <div className="min-h-screen bg-gray-50 py-12">


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Memoize packing list generation in new trip form

💡 What:
Wrapped `generatePackingList` and the item counting `.reduce()` in a `useMemo` hook inside `app/dashboard/new/page.tsx`.

🎯 Why:
The trip creation form uses controlled inputs, meaning it re-renders on every keystroke. Without memoization, the computationally expensive packing list generation and array reduction were being recalculated unnecessarily on every keystroke, leading to potential UI lag.

📊 Impact:
Prevents unnecessary recalculations of the packing list array during form entry. The array generation now only runs when the relevant form dependencies (dates, type, transport, toggle) actually change.

🔬 Measurement:
Start typing in the trip name or destination inputs while the "Start with a template" option is enabled. The inputs should remain responsive without dropping frames due to synchronous recalculation.

---
*PR created automatically by Jules for task [7538817062848935518](https://jules.google.com/task/7538817062848935518) started by @mvng*