### PR TITLE
🔍 Scout: Add native sitemap and robots.txt generation

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  // SEO Rationale: Dynamically determine the base URL to prevent crawler issues across environments.
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+  return {
+    rules: {
+      // SEO Rationale: Allow general crawling but deliberately exclude private, authenticated routes.
+      // This prevents search engines from indexing user-specific or sensitive pages, preserving crawl budget.
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/inventory/',
+        '/luggage/',
+        '/api/'
+      ],
+    },
+    // SEO Rationale: Provide the sitemap URL to search engines for efficient crawling.
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // SEO Rationale: Dynamically determine the base URL to prevent crawler issues across environments.
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+  return [
+    {
+      // SEO Rationale: The homepage is the primary entry point and gets the highest priority.
+      // We omit dynamic lastModified to avoid falsely signaling continuous changes.
+      url: `${baseUrl}`,
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      // SEO Rationale: The login page is included as it is public, but with a lower priority.
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    // SEO Rationale: Private authenticated routes (/dashboard, /settings, etc.) are excluded here
+    // as well as in robots.ts to prevent them from being crawled or indexed.
+    // Public shared trips (/trip/[id]) are omitted since they are dynamically generated
+    // and we don't list all user trips globally for privacy and scale reasons.
+  ];
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import robots from '../app/robots';
+import sitemap from '../app/sitemap';
+
+test.describe('SEO Configuration Tests', () => {
+  test('robots.ts should output valid structure', () => {
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+    const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+    const output = robots();
+
+    expect(output.sitemap).toBe(`${baseUrl}/sitemap.xml`);
+
+    const rules = Array.isArray(output.rules) ? output.rules[0] : output.rules;
+    expect(rules).toBeDefined();
+    expect(rules?.userAgent).toBe('*');
+    expect(rules?.allow).toBe('/');
+    expect(rules?.disallow).toContain('/dashboard/');
+    expect(rules?.disallow).toContain('/settings/');
+    expect(rules?.disallow).toContain('/inventory/');
+    expect(rules?.disallow).toContain('/luggage/');
+  });
+
+  test('sitemap.ts should output valid structure', () => {
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+    const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+    const output = sitemap();
+
+    expect(output.length).toBeGreaterThan(0);
+    expect(output[0].url).toBe(`${baseUrl}`);
+    expect(output[0].priority).toBe(1);
+
+    const urls = output.map(item => item.url);
+    expect(urls).toContain(`${baseUrl}/login`);
+    expect(urls).not.toContain(`${baseUrl}/dashboard`);
+    expect(urls).not.toContain(`${baseUrl}/settings`);
+  });
+});


### PR DESCRIPTION
💡 **What**
Implemented Next.js native dynamic sitemap (`app/sitemap.ts`) and robots.txt (`app/robots.ts`) file generation.

🎯 **Why**
The application lacked an explicit set of rules to guide search engine crawlers. By providing a `sitemap.xml`, we ensure all public pages (like the homepage and login) are easily discoverable. By providing a `robots.txt`, we can deliberately restrict crawlers from indexing private, authenticated routes (like `/dashboard` and `/settings`), which preserves our crawl budget for the pages that matter.

📊 **Impact**
- Improves overall site indexability.
- Ensures private user data/routes are actively kept out of search engine indexes.
- Resolves potential crawler issues across environments by dynamically generating the base URL.

🔬 **Verification**
- Run `pnpm test` to confirm the new `tests/seo.test.ts` unit tests pass.
- Start the server (`pnpm dev`) and manually visit `/sitemap.xml` and `/robots.txt` to verify proper output.

🔗 **References**
- [Next.js App Router - Metadata Files](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)
- [Google Search Central - Intro to robots.txt](https://developers.google.com/search/docs/crawling-indexing/robots/intro)

---
*PR created automatically by Jules for task [14944799058760951622](https://jules.google.com/task/14944799058760951622) started by @mvng*