### PR TITLE
🎨 Palette: Improve accessibility of inline edit action buttons

### DIFF
--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -725,9 +725,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         handleUpdateNotes(item.id, item.categoryId, item.packingListId, editingNotes?.notes || "")
                         setEditingNotes(null)
                       }}
-                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      title="Save note"
+                      aria-label={`Save note for ${item.name}`}
+                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-500"
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button
+                      onClick={() => setEditingNotes(null)}
+                      title="Cancel edit"
+                      aria-label="Cancel editing note"
+                      className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-gray-400"
+                    ><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -1241,9 +1248,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                               handleUpdateNotes(item.id, category.id, list.id, editingNotes?.notes || "")
                                               setEditingNotes(null)
                                             }}
-                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                                            title="Save note"
+                                            aria-label={`Save note for ${item.name}`}
+                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-500"
                                           ><Check className="w-3 h-3" /></button>
-                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                                          <button
+                                            onClick={() => setEditingNotes(null)}
+                                            title="Cancel edit"
+                                            aria-label="Cancel editing note"
+                                            className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-gray-400"
+                                          ><X className="w-3 h-3" /></button>
                                         </div>
                                       </div>
                                     ) : item.notes ? (
@@ -1270,7 +1284,12 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                     title="Add to departure checklist"
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center"
                                   ><Sunrise className="w-3.5 h-3.5" /></button>
-                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
+                                  <button
+                                    onClick={() => handleDelete(item.id, category.id, list.id)}
+                                    aria-label={`Remove ${item.name} from packing list`}
+                                    title="Remove item"
+                                    className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"
+                                  ><X className="w-4 h-4" /></button>
                                 </div>
                               )}
                             </li>


### PR DESCRIPTION
💡 What: Added accessible `aria-label`s, tooltips (`title`), and visible keyboard focus states (`focus:ring`) to the icon-only inline edit buttons (Save, Cancel, Delete) within the packing list component.

🎯 Why: Icon-only buttons lacking `aria-label`s are inaccessible to screen readers, and lacking clear focus rings makes keyboard navigation difficult.

📸 Before/After: Visual focus rings are now prominent on tab focus.

♿ Accessibility: Ensures interactive elements have descriptive accessible names and visible focus states, following WAI-ARIA and keyboard accessibility best practices.

---
*PR created automatically by Jules for task [5083972247242082923](https://jules.google.com/task/5083972247242082923) started by @mvng*