### PR TITLE
🔍 Scout: Add sitemap and robots.txt for crawlability

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,7 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+
+## 2024-05-24 - Document dynamic URL fallbacks for metadata
+**Learning:** Next.js uses an explicit environment variable pattern across environments for URLs. Hardcoding absolute fallbacks directly in tests causes brittleness across environments. Next.js metadata API allows rules properties for robots to be evaluated as either objects or arrays dynamically depending on internal typing.
+**Action:** Always test metadata dynamically. Avoid hardcoding testing base URLs. In tests, explicitly check for both array and object responses from Next.js APIs before accessing inner fields to avoid test suite crashes when Next.js alters the typing returned.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  // Define base URL dynamically and remove any trailing slashes
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SEO Rationale:
+  // - Allow crawling of public landing page and authentication entry points.
+  // - Disallow crawling of all private, authenticated routes (/dashboard, /settings, /inventory, /luggage)
+  //   to prevent search engines from attempting to index user-specific data or getting stuck in auth loops.
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Define base URL dynamically and remove any trailing slashes
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SEO Rationale:
+  // - Provide search engines with a sitemap to discover public static pages.
+  // - Exclude private pages.
+  // - Do not use dynamic `lastModified: new Date()` as this misleads search engines
+  //   into thinking static content changes constantly.
+  // - Priority is given to the main landing page.
+  return [
+    {
+      url: `${baseUrl}/`,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test'
+import robots from '../app/robots'
+import sitemap from '../app/sitemap'
+
+test.describe('SEO Metadata Generators', () => {
+  const getExpectedBaseUrl = () => {
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+    return rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+  }
+
+  test('robots.ts generates correct rules and sitemap URL', () => {
+    const expectedBaseUrl = getExpectedBaseUrl()
+    const result = robots()
+
+    expect(result.sitemap).toBe(`${expectedBaseUrl}/sitemap.xml`)
+
+    // Extract the rule object. Note that MetadataRoute.Robots allows rules to be an array or an object
+    const rules = Array.isArray(result.rules) ? result.rules[0] : result.rules
+
+    expect(rules).toBeDefined()
+    expect(rules?.userAgent).toBe('*')
+    expect(rules?.allow).toContain('/')
+    expect(rules?.allow).toContain('/login')
+    expect(rules?.disallow).toContain('/dashboard')
+    expect(rules?.disallow).toContain('/settings')
+    expect(rules?.disallow).toContain('/inventory')
+    expect(rules?.disallow).toContain('/luggage')
+  })
+
+  test('sitemap.ts generates correct static routes', () => {
+    const expectedBaseUrl = getExpectedBaseUrl()
+    const result = sitemap()
+
+    expect(Array.isArray(result)).toBe(true)
+    expect(result.length).toBe(2)
+
+    // Check index route
+    const indexRoute = result.find(route => route.url === `${expectedBaseUrl}/`)
+    expect(indexRoute).toBeDefined()
+    expect(indexRoute?.priority).toBe(1)
+    expect(indexRoute?.changeFrequency).toBe('weekly')
+
+    // Check login route
+    const loginRoute = result.find(route => route.url === `${expectedBaseUrl}/login`)
+    expect(loginRoute).toBeDefined()
+    expect(loginRoute?.priority).toBe(0.8)
+    expect(loginRoute?.changeFrequency).toBe('monthly')
+
+    // Ensure lastModified is not set (anti-pattern for static pages)
+    expect(indexRoute?.lastModified).toBeUndefined()
+    expect(loginRoute?.lastModified).toBeUndefined()
+  })
+})


### PR DESCRIPTION
💡 What: Implemented Next.js `robots.ts` and `sitemap.ts` metadata files to explicitly control crawler access and improve discoverability of public pages. Added corresponding Playwright tests to lock in the logic.
🎯 Why: Search engines need a clear `sitemap.xml` to discover the main entry points, while `robots.txt` ensures they do not waste crawl budget or index private user data (e.g. `/dashboard`, `/luggage`).
📊 Impact: Prevents authentication loop crawls, improves general crawl efficiency, and safely exposes public `/` and `/login` routes.
🔬 Verification: Run `pnpm test` to ensure `tests/seo.test.ts` passes, verifying that both static configurations render the exact correct Next.js arrays and objects dynamically.
🔗 References: Next.js Metadata Files Documentation, Google Search Central (Robots and Sitemaps).

---
*PR created automatically by Jules for task [173609379342067422](https://jules.google.com/task/173609379342067422) started by @mvng*