### PR TITLE
🎨 Palette: Improve accessibility of TripMembersSection

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-04-16 - Add missing ARIA labels and focus states to TripMembersSection
+**Learning:** `TripMembersSection` heavily utilized icon-only buttons (remove, add, cancel, confirm) without `aria-label`s, rendering them inaccessible to screen readers. Furthermore, keyboard focus indicators were missing on both these buttons and the inline input field.
+**Action:** Always verify that interactive elements, particularly icon-only buttons, possess descriptive `aria-label` attributes. Ensure keyboard accessibility by consistently applying `focus:outline-none` and `focus-visible:ring-2` (and optionally `focus-visible:ring-offset-1` for better visibility) to all buttons and form inputs.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,10 +58,11 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
               <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
               {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
@@ -84,8 +85,9 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
             title="Add member"
+            aria-label="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -100,7 +102,8 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
             value={newName}
             onChange={e => setNewName(e.target.value)}
             placeholder="Name (e.g. Peter, Grandma)"
-            className="text-xs px-2.5 py-1.5 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white w-48"
+            className="text-xs px-2.5 py-1.5 border border-gray-200 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-white w-48"
+            aria-label="New member name"
             onKeyDown={e => {
               if (e.key === 'Enter') handleAdd()
               if (e.key === 'Escape') { setIsAdding(false); setNewName(''); setError(null) }
@@ -110,15 +113,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
             title="Confirm"
+            aria-label="Confirm add member"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
             title="Cancel"
+            aria-label="Cancel add member"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
💡 What:
Added missing `aria-label` attributes to icon-only buttons (remove, add, confirm, cancel) and the inline input field in the `TripMembersSection` component.
Added explicit keyboard focus styles (`focus-visible:ring-2`) to all interactive elements within this section.

🎯 Why:
To ensure the member management section is fully accessible to screen reader users and keyboard navigators. Previously, screen readers could not identify the purpose of the icon-only buttons, and keyboard users could not easily see which element had focus.

📸 Before/After:
Before: Buttons had no discernible labels for screen readers, and tab focus was visually unclear.
After: Buttons are correctly labeled, and tab focus displays a clear blue ring.

♿ Accessibility:
- Added semantic `aria-label`s.
- Improved keyboard navigation with clear `focus-visible` indicators.

---
*PR created automatically by Jules for task [785774262442740053](https://jules.google.com/task/785774262442740053) started by @mvng*