### PR TITLE
🎨 Palette: Add keyboard accessibility to hover actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Fix keyboard visibility for hover-revealed buttons
+**Learning:** In Tailwind CSS, buttons or elements revealed using `group-hover:opacity-100` or `group-hover:block` must also include `group-focus-within` and/or `focus-visible` utility classes. Otherwise, these elements remain completely invisible to keyboard-only users who are navigating via the `Tab` key.
+**Action:** Always pair `group-hover:opacity-100` with `group-focus-within:opacity-100` (for child elements like tooltips) and `focus-visible:opacity-100` (for the interactive elements themselves) to ensure full accessibility.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -865,7 +865,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         {itemCount > 0 && <span className="text-xs text-gray-500">({itemCount})</span>}
                         <button
                           onClick={() => handleRemoveLuggage(tl.id, tl.luggageId)}
-                          className="ml-1 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"
+                          className="ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-gray-400 hover:text-red-500 transition-opacity focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"
                           aria-label={`Remove ${tl.luggage.name}`}
                         ><X className="w-3.5 h-3.5" /></button>
                       </div>

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}


### PR DESCRIPTION
💡 **What**
Added keyboard accessibility (`focus-visible` and `group-focus-within`) and descriptive `aria-label` attributes to hover-revealed elements in `TripMembersSection` and `PackingListSection`.

🎯 **Why**
Hover-only reveals (`opacity-0 group-hover:opacity-100`) make it impossible for keyboard-only users to discover and interact with core features like removing a trip member or unassigning luggage. This ensures full WCAG keyboard navigation compliance for these interactions.

📸 **Before/After**
*Before:* Pressing `Tab` to navigate through trip members or packing list items hid critical action buttons because they lacked focus-based visibility styles.
*After:* Focused action buttons and their tooltips now gracefully become visible and are outlined with a clear blue focus ring, allowing users to remove members or unassign luggage without a mouse.

♿ **Accessibility**
- Added explicit `focus-visible:ring-2` styling.
- Bound tooltip visibility to keyboard focus via `group-focus-within:opacity-100`.
- Ensured dynamically generated icon-only buttons have descriptive `aria-label` properties (e.g. `aria-label="Remove Derek"`).

---
*PR created automatically by Jules for task [3700089462099573814](https://jules.google.com/task/3700089462099573814) started by @mvng*