### PR TITLE
⚡ Bolt: Replace TaskCard JS hover state with native CSS

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2025-04-18 - Replacing JS hover state with CSS for performance
+**Learning:** Using React state (`useState`) coupled with `onMouseEnter` and `onMouseLeave` to control hover visibility triggers unnecessary component re-renders every time the mouse enters or leaves the element.
+**Action:** Replace JavaScript-controlled hover states with native Tailwind CSS utilities like `group`, `group-hover:opacity-100`, and `focus-within:opacity-100`. This delegates hover effects to the browser's rendering engine and prevents React from expending main-thread cycles to re-render the component.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,16 +20,16 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
+  // ⚡ Bolt Performance Optimization
+  // Why: Replaced JS-based hover state (useState + onMouseEnter/Leave) with native CSS (group + group-hover).
+  // Impact: Prevents unnecessary React component re-renders when hovering over the task card.
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
@@ -70,7 +69,7 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
           <button
             onClick={() => onEdit(task)}
             className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"


### PR DESCRIPTION
💡 **What**
Replaced the React `useState`-based hover tracking (`isHovered`) and associated `onMouseEnter`/`onMouseLeave` event handlers in the `TaskCard` component with native Tailwind CSS utilities (`group` and `group-hover:opacity-100`).

🎯 **Why**
Using React state for simple hover effects causes the component to re-render entirely every time the mouse enters or leaves the card. In long lists, this can cause noticeable UI jank and unnecessary main-thread work. Native CSS hover states are handled by the browser's compositor and do not trigger React re-renders.

📊 **Impact**
Eliminates 2 unnecessary React re-renders per hover interaction per task card. For users with large task lists, this reduces main-thread blocking time when moving the mouse across the page.

🔬 **Measurement**
1. Run `pnpm test` to ensure all functionality remains intact.
2. Open React DevTools Profiler, record a session, and hover over multiple `TaskCard` elements.
3. Observe that no re-renders are triggered for the `TaskCard` components during hover interactions.

---
*PR created automatically by Jules for task [13513300477285540479](https://jules.google.com/task/13513300477285540479) started by @mvng*