### PR TITLE
🎨 Palette: Improve keyboard accessibility for TripMembersSection

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve TripMembersSection keyboard navigation
+**Learning:** Found that custom avatar-only pills used `group-hover` to show tooltips and remove icons without also applying `group-focus-within` for keyboard users, making the action invisible when focused. The pills and adjacent action buttons were also missing `focus-visible:ring-2` styles and descriptive `aria-label`s.
+**Action:** When implementing hover-revealed action buttons or containers in Tailwind CSS, always include focus-based utility classes (e.g., `focus-within:opacity-100`, `group-focus-within:block`) on the container so that interactive elements become visible to keyboard users as they tab-navigate through the component.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
-                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                isOwner ? 'hover:bg-red-100 hover:text-red-600 focus-visible:bg-red-100 focus-visible:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,8 +85,9 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Add member"
+            aria-label="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -110,15 +112,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Confirm"
+            aria-label="Confirm add member"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Cancel"
+            aria-label="Cancel add member"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
💡 What:
Added missing accessibility attributes and keyboard navigation support to the `TripMembersSection` component.
- Added descriptive `aria-label`s to the icon-only avatar pills, the "Add member" button, the "Confirm" check button, and the "Cancel" cross button.
- Added explicit `focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` styles to all interactive elements to provide clear keyboard focus indicators.
- Refactored the custom hover-revealed states for tooltips and delete icons (`X`) to also trigger on focus by combining `group-hover` with `group-focus-within` (e.g., `group-hover:hidden group-focus-within:hidden`).

🎯 Why:
The previous implementation relied solely on pointer events (`onClick`, `hover`) and lacked proper ARIA labels. This meant that screen-reader users could not easily distinguish between members (or their actions) and keyboard-only users could not navigate the section or discover the hidden remove functionality, leading to a degraded and inaccessible experience.

📸 Before/After:
Before: The pills and add/cancel/confirm buttons only reacted to hover and lacked a focus ring when tabbing. Tooltips/remove icons were inaccessible via keyboard.
After: All buttons have a clear blue focus ring. When tabbing to a member pill, the tooltip and 'X' delete icon natively appear exactly as they do on mouse hover.

♿ Accessibility:
- Improves screen-reader context for actions on members.
- Improves keyboard navigation for discovering hidden interactions using `group-focus-within`.

---
*PR created automatically by Jules for task [16164417973270163208](https://jules.google.com/task/16164417973270163208) started by @mvng*