### PR TITLE
🔍 Scout: Add sitemap and robots for search discoverability

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-04-19 - [Next.js App Router Native Sitemap and Robots]
+**Learning:** Next.js App Router applications lack native `sitemap.xml` and `robots.txt` unless explicitly defined via `app/sitemap.ts` and `app/robots.ts` returning `MetadataRoute.Sitemap` and `MetadataRoute.Robots` objects. Furthermore, handling `process.env.NEXT_PUBLIC_APP_URL` safely involves trimming potential trailing slashes before concatenating them to avoid double-slash URL errors during dynamic metadata generation.
+**Action:** When auditing Next.js App Router projects for crawlability, always ensure `app/sitemap.ts` and `app/robots.ts` exist, are well-tested via Playwright, strictly omit private routes, and safely handle dynamic `baseUrl` trailing slashes.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,19 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  // Define base URL, handling dynamic environments and trimming trailing slashes safely.
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      // SEO Rationale: Allow search crawlers to index public-facing landing and auth pages
+      allow: ['/', '/login'],
+      // SEO Rationale: Prevent search crawlers from accessing private, authenticated routes to save crawl budget and protect user privacy
+      disallow: ['/dashboard/', '/settings/', '/inventory/', '/luggage/'],
+    },
+    // SEO Rationale: Provide the location of the sitemap to help search engines discover allowed pages efficiently
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,22 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Define base URL, handling dynamic environments and trimming trailing slashes safely.
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SEO Rationale: Only index public pages. Private routes are omitted from the sitemap.
+  // We avoid `lastModified: new Date()` as it is an anti-pattern that inaccurately tells search engines the content has changed upon every request.
+  return [
+    {
+      url: `${baseUrl}/`,
+      changeFrequency: 'weekly',
+      priority: 1, // High priority for the main landing page
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8, // Important page, but less priority than home
+    },
+  ]
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+import robots from '../app/robots'
+import sitemap from '../app/sitemap'
+
+test.describe('SEO Configuration Tests', () => {
+  const getBaseUrl = () => {
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+    return rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+  }
+
+  test('robots.ts should allow public and disallow private routes', () => {
+    const robotsData = robots()
+    const baseUrl = getBaseUrl()
+
+    // Assert that rules object exists
+    expect(robotsData.rules).toBeDefined()
+
+    // Evaluate rules as array or single object
+    const rules = Array.isArray(robotsData.rules) ? robotsData.rules[0] : robotsData.rules
+
+    // Assert basic rules structure
+    expect(rules).toBeDefined()
+    expect(rules.userAgent).toBe('*')
+
+    // Assert allowed paths
+    expect(rules.allow).toContain('/')
+    expect(rules.allow).toContain('/login')
+
+    // Assert disallowed paths
+    expect(rules.disallow).toContain('/dashboard/')
+    expect(rules.disallow).toContain('/settings/')
+    expect(rules.disallow).toContain('/inventory/')
+    expect(rules.disallow).toContain('/luggage/')
+
+    // Assert sitemap URL
+    expect(robotsData.sitemap).toBe(`${baseUrl}/sitemap.xml`)
+  })
+
+  test('sitemap.ts should contain public routes with appropriate priority', () => {
+    const sitemapData = sitemap()
+    const baseUrl = getBaseUrl()
+
+    expect(Array.isArray(sitemapData)).toBe(true)
+    expect(sitemapData.length).toBe(2)
+
+    // Find the homepage route
+    const homeRoute = sitemapData.find(route => route.url === `${baseUrl}/`)
+    expect(homeRoute).toBeDefined()
+    expect(homeRoute?.changeFrequency).toBe('weekly')
+    expect(homeRoute?.priority).toBe(1)
+
+    // Find the login route
+    const loginRoute = sitemapData.find(route => route.url === `${baseUrl}/login`)
+    expect(loginRoute).toBeDefined()
+    expect(loginRoute?.changeFrequency).toBe('monthly')
+    expect(loginRoute?.priority).toBe(0.8)
+  })
+})


### PR DESCRIPTION
💡 **What:** Added `app/sitemap.ts` and `app/robots.ts` using Next.js Metadata Route APIs to generate a dynamic `sitemap.xml` and `robots.txt`. Added a new Playwright unit test to assert the config structure.

🎯 **Why:** To improve search visibility and crawlability. Search engines require `sitemap.xml` to discover public pages effectively, and `robots.txt` is necessary to restrict crawling of private, authenticated paths (like `/dashboard` and `/settings`) to save crawl budget and protect privacy.

📊 **Impact:** Enables proper indexing of the landing and authentication pages while keeping user-specific paths completely un-crawled, improving overall SEO hygiene.

🔬 **Verification:** Verified via `tests/seo.test.ts` to confirm correct Next.js MetadataRoute outputs.

🔗 **References:** [Next.js App Router Metadata Files](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [5511468402681160896](https://jules.google.com/task/5511468402681160896) started by @mvng*