### PR TITLE
🔍 Scout: [SEO] Implement dynamic robots.txt and sitemap.xml to manage crawlability

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-03-15 - [Static Routing Sitemap Optimization]
+**Learning:** When generating a `sitemap.ts` in Next.js, using `lastModified: new Date()` or similar dynamic dates for static routes (like `/` or `/login`) is an SEO anti-pattern. It inaccurately signals to search engines that the content has changed upon every request or build, potentially reducing trust in the sitemap's accuracy over time.
+**Action:** Omit the `lastModified` property entirely for static or infrequently updated routes in `sitemap.ts` to maintain sitemap integrity and avoid misleading crawlers.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,21 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  // Get base URL and safely trim any trailing slash to prevent double slash errors in paths
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SCOUT SEO RATIONALE:
+  // - Allow public pages like /, /login, and shared /trip/[id] routes to be indexed
+  //   since they contain shareable public value or act as landing pages.
+  // - Disallow private, authenticated-only routes (/dashboard, /settings, /inventory, /luggage)
+  //   to prevent search engines from crawling inaccessible pages, optimizing crawl budget.
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login', '/trip/'],
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Get base URL and safely trim any trailing slash
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SCOUT SEO RATIONALE:
+  // - Add public, indexable routes to the sitemap to ensure search engines can discover them.
+  // - We prioritize the landing page (1.0) and include the login page (0.8).
+  // - We deliberately exclude authenticated routes (/dashboard, etc.) and omit lastModified
+  //   for static routes as an SEO best practice to prevent misleading crawlers.
+  return [
+    {
+      url: `${baseUrl}/`,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+import robots from '../app/robots'
+import sitemap from '../app/sitemap'
+
+test.describe('SEO Configuration Tests', () => {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const expectedBaseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  test('robots.ts should return correctly structured rules', () => {
+    const robotsData = robots()
+
+    // Convert rules to an array if it's not already one, to handle both configurations
+    const rulesArray = Array.isArray(robotsData.rules) ? robotsData.rules : [robotsData.rules]
+
+    // Find the catch-all user agent rule
+    const generalRule = rulesArray.find(r => r.userAgent === '*')
+    expect(generalRule).toBeDefined()
+
+    // Verify allow/disallow lists
+    expect(generalRule?.allow).toContain('/')
+    expect(generalRule?.allow).toContain('/login')
+    expect(generalRule?.allow).toContain('/trip/')
+
+    expect(generalRule?.disallow).toContain('/dashboard')
+    expect(generalRule?.disallow).toContain('/settings')
+    expect(generalRule?.disallow).toContain('/inventory')
+    expect(generalRule?.disallow).toContain('/luggage')
+
+    // Verify sitemap URL
+    expect(robotsData.sitemap).toBe(`${expectedBaseUrl}/sitemap.xml`)
+  })
+
+  test('sitemap.ts should return valid static routes without lastModified', () => {
+    const sitemapData = sitemap()
+
+    expect(Array.isArray(sitemapData)).toBe(true)
+    expect(sitemapData.length).toBeGreaterThan(0)
+
+    // Verify home page
+    const homeRoute = sitemapData.find(route => route.url === `${expectedBaseUrl}/`)
+    expect(homeRoute).toBeDefined()
+    expect(homeRoute?.priority).toBe(1)
+    expect(homeRoute?.lastModified).toBeUndefined()
+
+    // Verify login page
+    const loginRoute = sitemapData.find(route => route.url === `${expectedBaseUrl}/login`)
+    expect(loginRoute).toBeDefined()
+    expect(loginRoute?.priority).toBe(0.8)
+    expect(loginRoute?.lastModified).toBeUndefined()
+  })
+})


### PR DESCRIPTION
💡 **What:** Added `app/robots.ts` and `app/sitemap.ts` to generate dynamic `robots.txt` and `sitemap.xml` using native Next.js Metadata Route files. Also added unit tests in `tests/seo.test.ts` to verify their configurations.

🎯 **Why:** To guide search engine crawlers effectively. Public pages like `/` and `/login` are explicitly allowed and prioritized in the sitemap for indexing. Conversely, authenticated and private routes (`/dashboard`, `/settings`, `/inventory`, `/luggage`) are disallowed in `robots.txt` and omitted from the sitemap to conserve crawl budget and avoid exposing inaccessible routes.

📊 **Impact:** Improves search engine discoverability of important landing pages and optimizes crawl budget by keeping crawlers away from authenticated paths.

🔬 **Verification:** 
- `pnpm test` successfully executes the newly added `seo.test.ts` to verify correct `robots.ts` rules and `sitemap.ts` properties.
- Dynamic URLs are safely constructed by trimming trailing slashes, ensuring no duplicate slash paths.
- Code has been verified by linting and automated tests.

🔗 **References:** 
- [Next.js Metadata Route docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)
- [Next.js Sitemap docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [4206460475691802597](https://jules.google.com/task/4206460475691802597) started by @mvng*