### PR TITLE
🎨 Palette: Add accessible labels to member section buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Enhance TripMembersSection Accessibility
+**Learning:** Found an accessibility anti-pattern in `components/TripMembersSection.tsx` where icon-only action buttons (Remove Member, Add Member, Confirm Add, Cancel Add) lacked `aria-label`s and consistent keyboard focus states. The issue is especially prominent in small sub-components acting as dynamic lists or inline forms where multiple inline actions exist.
+**Action:** Always ensure that icon-only interactive elements in mapping functions or inline forms receive proper `aria-label` attributes (e.g., interpolating `Remove ${member.name}`). Additionally, pair visual hover states with explicit `focus-visible:ring-2` (and offset) utility classes so screen readers and keyboard users can effectively navigate and interact with these controls.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,10 +58,11 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
-              title={member.name}
+              title={isOwner ? `Remove ${member.name}` : member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
               <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
               {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
@@ -84,8 +85,9 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
             title="Add member"
+            aria-label="Add new member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -110,15 +112,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
             title="Confirm"
+            aria-label="Confirm adding member"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-1"
             title="Cancel"
+            aria-label="Cancel adding member"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
💡 What: Added accessible `aria-label` attributes and explicit keyboard focus states (`focus-visible`) to the icon-only interaction buttons within the `TripMembersSection` component.
🎯 Why: Users relying on screen readers or keyboard navigation could not easily understand the function of the "Remove Member", "Add Member", "Confirm", or "Cancel" icon buttons, nor could they easily see when the elements received focus.
📸 Before/After: N/A - Visual UI remains the same, but keyboard focus ring and screen reader annotations are now properly established.
♿ Accessibility: Ensures that dynamic mapped items and inline form controls provide semantic meaning and visual indication for non-mouse users.

---
*PR created automatically by Jules for task [12697069143829260962](https://jules.google.com/task/12697069143829260962) started by @mvng*