### PR TITLE
🎨 Palette: Add Escape key support to close modals

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2025-02-23 - Add accessible close buttons to modals
+**Learning:** Found a pattern across multiple modal components (`PasteListModal`, `inventory/AddCategoryModal`, `inventory/AddItemModal`) where the modals lacked `Escape` key close handlers, preventing proper keyboard accessibility when users needed to close the dialogs.
+**Action:** When creating or editing modals in the future, ensure that keyboard accessibility (specifically the `Escape` key) is implemented using `document.addEventListener('keydown')` to close the modals, and properly cleaned up on unmount.

--- a/components/PasteListModal.tsx
+++ b/components/PasteListModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useTransition, useMemo } from 'react'
+import { useState, useTransition, useMemo, useEffect } from 'react'
 import { importItemsToTrip } from '@/actions/packing.actions'
 
 interface PasteListModalProps {
@@ -189,6 +189,14 @@ export default function PasteListModal({ tripId, onClose, onSuccess }: PasteList
       }
     })
   }
+
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [onClose])
 
   return (
     <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4" onClick={(e) => {

--- a/components/inventory/AddCategoryModal.tsx
+++ b/components/inventory/AddCategoryModal.tsx
@@ -20,6 +20,14 @@ export default function AddCategoryModal({
     inputRef.current?.focus()
   }, [])
 
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [onClose])
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!name.trim()) return

--- a/components/inventory/AddItemModal.tsx
+++ b/components/inventory/AddItemModal.tsx
@@ -27,6 +27,14 @@ export default function AddItemModal({
     inputRef.current?.focus()
   }, [])
 
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [onClose])
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!name.trim()) return


### PR DESCRIPTION
💡 What: Added `Escape` key event listeners to `PasteListModal`, `inventory/AddCategoryModal`, and `inventory/AddItemModal`.
🎯 Why: To improve keyboard accessibility and provide a standard, expected way for users to dismiss these dialogs without needing a mouse.
📸 Before/After: Visual changes not applicable.
♿ Accessibility: Ensures users navigating via keyboard can close these specific modals using the `Escape` key.

---
*PR created automatically by Jules for task [3124583048080704087](https://jules.google.com/task/3124583048080704087) started by @mvng*