### PR TITLE
🔍 Scout: Add sitemap and robots.txt

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-04-22 - [Sitemap and Robots Configuration]
+**Learning:** When creating a `sitemap.ts` for a Next.js application with user-generated content, avoid including massive dynamic route collections (like shared lists) and use fixed `lastModified` dates instead of `new Date()`. Additionally, dynamically generated base URLs must be cleaned of trailing slashes to prevent `//sitemap.xml` double-slash issues. Next.js 14 `MetadataRoute.Robots` structure for rules may wrap the object in an array which must be checked in unit tests.
+**Action:** Always test metadata exports directly by calling `robots()` or `sitemap()` in a Playwright unit test to assert the exported structures, and ensure base URLs are dynamically calculated and trimmed of trailing slashes.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  // Use NEXT_PUBLIC_APP_URL for local/staging, fallback to production URL
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SCOUT SEO RATIONALE:
+  // We allow crawlers on public routes like the homepage (/) and login (/login).
+  // We disallow crawling on private, authenticated routes (/dashboard, /settings, /inventory, /luggage)
+  // to save crawl budget and prevent search engines from trying to index pages that redirect to login.
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Use NEXT_PUBLIC_APP_URL for local/staging, fallback to production URL
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SCOUT SEO RATIONALE:
+  // We only include static public routes like the homepage (/) and login (/login).
+  // Dynamic shared trips are not included to prevent creating massively large sitemaps
+  // for user-generated content that may be private or ephemeral.
+  // We also use a fixed lastModified date to avoid the anti-pattern of updating it on every request.
+  const fixedDate = new Date('2024-04-22')
+
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: fixedDate,
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: fixedDate,
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test'
+import robots from '../app/robots'
+import sitemap from '../app/sitemap'
+
+test.describe('SEO Configuration', () => {
+  test('robots() should return correct disallow rules and sitemap URL', () => {
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+    const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+    const robotsData = robots()
+
+    // Check rules structure based on Next.js 14 MetadataRoute.Robots structure
+    const rules = Array.isArray(robotsData.rules) ? robotsData.rules[0] : robotsData.rules
+
+    expect(rules).toBeDefined()
+    expect(rules?.userAgent).toBe('*')
+    expect(rules?.allow).toBe('/')
+    expect(rules?.disallow).toEqual(['/dashboard', '/settings', '/inventory', '/luggage'])
+
+    expect(robotsData.sitemap).toBe(`${baseUrl}/sitemap.xml`)
+  })
+
+  test('sitemap() should return correct static routes and priority', () => {
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+    const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+    const sitemapData = sitemap()
+
+    expect(sitemapData.length).toBe(2)
+
+    expect(sitemapData[0].url).toBe(`${baseUrl}`)
+    expect(sitemapData[0].priority).toBe(1)
+    expect(sitemapData[0].changeFrequency).toBe('monthly')
+
+    expect(sitemapData[1].url).toBe(`${baseUrl}/login`)
+    expect(sitemapData[1].priority).toBe(0.8)
+    expect(sitemapData[1].changeFrequency).toBe('yearly')
+  })
+})


### PR DESCRIPTION
💡 **What:** Added `app/sitemap.ts` and `app/robots.ts` using Next.js App Router native metadata generation conventions.
🎯 **Why:** To improve search engine visibility for public pages (Homepage, Login) while actively preventing crawlers from attempting to index private user routes (`/dashboard`, `/settings`, `/inventory`, `/luggage`) which waste crawl budget and lead to login redirects.
📊 **Impact:** Increases discoverability of the landing page and preserves SEO crawl budget by explicitly disallowing private routes. Fixes trailing slash URL bugs in Next.js dynamically generated base paths.
🔬 **Verification:** Validated by `tests/seo.test.ts` which imports and tests the `MetadataRoute` generators directly in Playwright, confirming correct Disallow rules and Sitemap XML endpoints. All linting and tests pass.
🔗 **References:** [Next.js sitemap.xml docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap), [Next.js robots.txt docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots).

---
*PR created automatically by Jules for task [1984049673636426870](https://jules.google.com/task/1984049673636426870) started by @mvng*