### PR TITLE
🎨 Palette: Add keyboard accessibility and aria-labels to trip member avatars

### DIFF
--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,16 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus-visible:outline-none focus-visible:ring-blue-400 focus-visible:ring-offset-1 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
-              title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}


### PR DESCRIPTION
💡 **What**: Added proper keyboard focus rings, `group-focus-within` visibility handling for custom tooltips and remove icons, and an `aria-label` attribute to the avatar remove buttons in `TripMembersSection.tsx`.

🎯 **Why**: Previously, the 'Remove' state and custom tooltip for trip members were only available on mouse hover (`group-hover`). This made the feature completely inaccessible to keyboard-only users who use the Tab key to navigate, and the lack of an `aria-label` meant screen readers lacked proper context.

📸 **Before/After**: Keyboard navigation (Tab) now correctly highlights the avatar, reveals the custom tooltip, and shows the 'X' remove icon. 

♿ **Accessibility**: Improved keyboard discoverability and screen reader support for the remove member interaction.

---
*PR created automatically by Jules for task [18327307897559102547](https://jules.google.com/task/18327307897559102547) started by @mvng*