### PR TITLE
🎨 Palette: Add aria-labels to icon buttons in PackingListSection

### DIFF
--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -726,8 +726,9 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         setEditingNotes(null)
                       }}
                       className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      aria-label="Save note"
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button onClick={() => setEditingNotes(null)} aria-label="Cancel note edit" className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -748,6 +749,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
             <button
               onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
               title="Add/Edit Note"
+              aria-label="Add/Edit Note"
               className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
             ><MessageSquare className="w-3.5 h-3.5" /></button>
             <button
@@ -1242,8 +1244,9 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                               setEditingNotes(null)
                                             }}
                                             className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                                            aria-label="Save note"
                                           ><Check className="w-3 h-3" /></button>
-                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                                          <button onClick={() => setEditingNotes(null)} aria-label="Cancel note edit" className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
                                         </div>
                                       </div>
                                     ) : item.notes ? (
@@ -1263,14 +1266,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                   <button
                                     onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
                                     title="Add/Edit Note"
+                                    aria-label="Add/Edit Note"
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
                                   ><MessageSquare className="w-3.5 h-3.5" /></button>
                                   <button
                                     onClick={() => handleTogglePackLast(item.id, category.id, list.id, item.packLast)}
                                     title="Add to departure checklist"
+                                    aria-label="Add to departure checklist"
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center"
                                   ><Sunrise className="w-3.5 h-3.5" /></button>
-                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
+                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} aria-label="Delete item" className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
                                 </div>
                               )}
                             </li>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to icon-only buttons (`<Check>`, `<X>`, `<MessageSquare>`, `<Sunrise>`) inside the `PackingListSection` component.
🎯 Why: Icon-only buttons without accessible labels cannot be correctly interpreted by screen readers. This makes actions like "Save note", "Cancel note edit", "Delete item", and "Add to departure checklist" inaccessible to visually impaired users.
📸 Before/After: No visual changes.
♿ Accessibility: Ensures that screen reader users can understand and interact with all list item controls.

---
*PR created automatically by Jules for task [4802634285850569365](https://jules.google.com/task/4802634285850569365) started by @mvng*