### PR TITLE
🔍 Scout: Add dynamic sitemap and robots.txt

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2025-02-23 - [Static LastModified in Sitemap]
+**Learning:** Using `lastModified: new Date()` in Next.js `sitemap.ts` for static pages inaccurately signals constant content churn on every request/build, potentially leading search engines to de-prioritize or ignore the sitemap signals.
+**Action:** Always use hardcoded static dates or actual modification timestamps from a database, avoiding `new Date()` for unchanging static paths.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SEO Rationale:
+  // We allow crawlers to index public marketing pages like the homepage and login page
+  // to ensure maximum search visibility.
+  // We deliberately exclude private, authenticated routes (dashboard, settings, inventory, luggage)
+  // to prevent sensitive user data from being indexed and to optimize crawl budget on public pages.
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SEO Rationale:
+  // We prioritize the home page (priority 1.0) as it's the primary landing page for the application.
+  // The login page is included (priority 0.8) for brand discovery.
+  // We avoid using `lastModified: new Date()` for static routes as it inaccurately signals content churn.
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date('2024-01-01'),
+      changeFrequency: 'yearly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date('2024-01-01'),
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test'
+import sitemap from '../app/sitemap'
+import robots from '../app/robots'
+
+test.describe('SEO Configuration', () => {
+  test('sitemap generates correctly', () => {
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+    const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+    const result = sitemap()
+
+    expect(result).toHaveLength(2)
+
+    expect(result[0].url).toBe(`${baseUrl}/`)
+    expect(result[0].priority).toBe(1)
+    expect(result[0].changeFrequency).toBe('yearly')
+
+    expect(result[1].url).toBe(`${baseUrl}/login`)
+    expect(result[1].priority).toBe(0.8)
+    expect(result[1].changeFrequency).toBe('yearly')
+  })
+
+  test('robots generates correctly', () => {
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+    const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+    const result = robots()
+
+    expect(result.rules).toEqual({
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage'],
+    })
+
+    expect(result.sitemap).toBe(`${baseUrl}/sitemap.xml`)
+  })
+})


### PR DESCRIPTION
💡 **What:** Added dynamic `app/sitemap.ts` and `app/robots.ts` to implement technical SEO fundamentals via Next.js App Router metadata API.
🎯 **Why:** To improve search engine crawlability by explicitly defining public marketing pages (homepage, login) and protecting private, authenticated user routes (`/dashboard`, `/settings`, `/inventory`, `/luggage`) from being indexed.
📊 **Impact:** Enables accurate indexing of public landing pages while preserving crawl budget and user privacy by preventing crawlers from hitting authenticated endpoints.
🔬 **Verification:** Evaluated via Playwright unit tests in `tests/seo.test.ts`. Verified correct payload generation logic without hardcoding brittle fallback URLs in assertions.
🔗 **References:** [Next.js App Router Metadata Routing](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap) and SEO best practices for preventing false `lastModified` content churn.

---
*PR created automatically by Jules for task [8930227023157693905](https://jules.google.com/task/8930227023157693905) started by @mvng*