### PR TITLE
🎨 Palette: Improve TaskCard accessibility and keyboard navigation

### DIFF
--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,21 +20,19 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? `Mark "${task.title}" as not done` : `Mark "${task.title}" as done`}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full transition-colors ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,17 +67,19 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            aria-label={`Edit task "${task.title}"`}
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors"
             title="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            aria-label={`Delete task "${task.title}"`}
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 transition-colors"
             title="Delete task"
           >
             <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
💡 What: Refactored `TaskCard` to remove JavaScript-based hover states, replacing them with native Tailwind `group` and `group-hover` utilities. Added `aria-label`s and `focus-visible` styling to the edit, delete, and status toggle buttons.

🎯 Why: The previous JS-based `onMouseEnter` state made the action buttons completely inaccessible to keyboard-only users because they couldn't be discovered via Tab navigation. Icon-only buttons lacked screen reader context. The new CSS-driven approach is more performant and natively supports `focus-within`, allowing keyboard users to reveal the actions.

📸 Before/After: Action buttons were completely invisible to keyboard focus and lacked focus rings. Now, pressing Tab reveals the hidden buttons and applies a clear blue/red focus ring.

♿ Accessibility:
- Added `aria-label` to the Edit button (`Edit task "Title"`)
- Added `aria-label` to the Delete button (`Delete task "Title"`)
- Added `aria-label` to the Status toggle (`Mark "Title" as [done/not done]`)
- Added `focus-within:opacity-100` to the action container
- Added `focus-visible:ring-2` to all interactive elements

---
*PR created automatically by Jules for task [18325331539679010985](https://jules.google.com/task/18325331539679010985) started by @mvng*