### PR TITLE
🔍 Scout: [Sitemap and Robots Configuration]

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-05-20 - [Sitemap and Robots Configuration]
+**Learning:** Added `sitemap.ts` and `robots.ts` using Next.js framework-native APIs. Excluded private routes (dashboard, inventory, etc.) and API routes from crawlers. Dynamically computed base URLs to ensure consistency between development and production. Avoided using `lastModified: new Date()` in sitemap for static pages.
+**Action:** When working on overall crawlability, ensure the Next.js `robots.ts` and `sitemap.ts` properly allow public content while actively disallowing private app sections to preserve crawl budget and prevent unauthenticated page indexing.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,18 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+  // SEO Rationale: We allow crawling of the main public pages to maximize visibility,
+  // but explicitly disallow indexing of private authenticated routes (/dashboard, /settings, /inventory, /luggage)
+  // and user-specific shared pages (/trip/) to protect user privacy and prevent index bloat with unhelpful pages.
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage', '/trip/', '/api/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+  // SEO Rationale: We only include public static routes in the sitemap to ensure search engines
+  // focus their crawl budget on discoverable marketing pages. Private pages (like /dashboard or /trip)
+  // are excluded because they require authentication or are user-specific.
+  // Note: We avoid using `lastModified: new Date()` for static routes as it inaccurately signals
+  // constant updates to crawlers.
+  return [
+    {
+      url: `${baseUrl}/`,
+      changeFrequency: 'weekly',
+      priority: 1.0,
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ];
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app';
+const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+
+test.describe('SEO Configuration', () => {
+  test('robots.txt prevents indexing of private routes', async ({ request }) => {
+    const response = await request.get('/robots.txt');
+    expect(response.status()).toBe(200);
+
+    const text = await response.text();
+    expect(text).toContain('User-Agent: *');
+    expect(text).toContain('Allow: /');
+    expect(text).toContain('Allow: /login');
+    expect(text).toContain('Disallow: /dashboard');
+    expect(text).toContain('Disallow: /settings');
+    expect(text).toContain('Disallow: /inventory');
+    expect(text).toContain('Disallow: /luggage');
+    expect(text).toContain('Disallow: /trip/');
+    expect(text).toContain('Disallow: /api/');
+    expect(text).toContain(`Sitemap: ${baseUrl}/sitemap.xml`);
+  });
+
+  test('sitemap.xml contains only public static routes', async ({ request }) => {
+    const response = await request.get('/sitemap.xml');
+    expect(response.status()).toBe(200);
+
+    const text = await response.text();
+    expect(text).toContain('<loc>' + baseUrl + '/</loc>');
+    expect(text).toContain('<loc>' + baseUrl + '/login</loc>');
+    expect(text).not.toContain('<loc>' + baseUrl + '/dashboard</loc>');
+  });
+});


### PR DESCRIPTION
💡 **What:** Added Next.js native `app/sitemap.ts` and `app/robots.ts` configuration files to explicitly control crawl scope and provide a sitemap for public static pages. Added a test suite to verify indexing configurations. Updated `.jules/scout.md` journal.
🎯 **Why:** To improve search engine crawlability by explicitly allowing indexing of public pages (`/`, `/login`) while preventing search engines from attempting to crawl or index private, unauthenticated user pages (`/dashboard`, `/inventory`, `/luggage`, `/trip`, `/settings`).
📊 **Impact:** Prevents crawl budget waste and protects private routes from index bloat, while guiding crawlers to the important marketing pages.
🔬 **Verification:** `pnpm test tests/seo.test.ts` passes, confirming expected sitemap and robots.txt structures.
🔗 **References:** Next.js Metadata Files Documentation (https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

---
*PR created automatically by Jules for task [5935683970406953955](https://jules.google.com/task/5935683970406953955) started by @mvng*