### PR TITLE
🎨 Palette: [UX improvement] Add keyboard and screen reader accessibility to inventory item actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve keyboard accessibility on mapped inventory item actions
+**Learning:** Found that secondary action buttons (Favorite, Edit, Delete) within the mapped inventory list (`CategorySection`) were relying purely on `hover` states and lacked proper `aria-label`s and `focus-visible` styles, making them invisible and inaccessible to keyboard-only and screen-reader users.
+**Action:** When implementing lists of items with actions, always ensure action buttons receive context-aware `aria-label`s (interpolating the item name) and explicit keyboard focus states (`focus-visible:ring-2`) so they are fully accessible to non-mouse users.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -89,7 +89,8 @@ export default function CategorySection({
                 onClick={() => onToggleFavorite(item)}
                 disabled={isPending}
                 title={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50"
+                aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`}
+                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm"
               >
                 {item.isFavorite ? (
                   '⭐'
@@ -118,7 +119,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +140,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What: Added context-aware `aria-label` attributes and keyboard focus visible states (`focus-visible:ring-2`) to the "Favorite", "Edit", and "Delete" icon buttons inside `CategorySection.tsx`.
🎯 Why: Previously, these icon-only buttons relied purely on mouse hover for discovery and lacked proper labeling, rendering them completely inaccessible to keyboard-only users and screen readers.
📸 Before/After: Before, tabbing through the list showed no visible focus indicators on the actions. Now, an appropriate ring highlights each action.
♿ Accessibility: Improved screen reader context (e.g., "Delete Passport" instead of "Delete") and clear visual keyboard focus markers.

---
*PR created automatically by Jules for task [16561195716910267136](https://jules.google.com/task/16561195716910267136) started by @mvng*