### PR TITLE
🔍 Scout: [Add robots.txt to control crawl scope]

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-03-15 - [Dynamic robots.txt Scope Control]
+**Learning:** Hardcoding a dynamic fallback URL in Playwright tests testing `robots.txt` can lead to brittle assertions if the fallback value doesn't exactly match the application's fallback environment. Next.js `robots.txt` requires careful trimming of trailing slashes to avoid double slashes when generating `host` and `sitemap` rules.
+**Action:** Always dynamically calculate the expected `baseUrl` and ensure trailing slashes are removed in tests for Next.js metadata routes, exactly mimicking the application's logic.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,30 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Creating a dynamic robots.txt file to control search engine crawl scope.
+// - Allows crawling of public landing pages (/) and authentication pages (/login).
+// - Explicitly disallows crawling of private authenticated routes (/dashboard, /settings, /inventory, /luggage) to prevent indexing of user-specific data or redirect loops.
+// - Explicitly disallows crawling of user-specific shared trip pages (/trip/*) to protect user privacy and avoid duplicate thin-content indexing if claims are empty.
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  // Safely trim trailing slash if it exists
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: [
+        '/dashboard',
+        '/settings',
+        '/inventory',
+        '/luggage',
+        '/trip/', // Prevent crawling of dynamic trip pages e.g. /trip/[id]
+        '/api/',  // Prevent crawling of API endpoints
+      ],
+    },
+    // Commented out until sitemap.ts is implemented to avoid broken sitemap links
+    // sitemap: `${baseUrl}/sitemap.xml`,
+    host: baseUrl,
+  }
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('SEO - robots.txt', () => {
+  test('robots.txt should render with correct rules and host', async ({ request }) => {
+    // Determine the base URL dynamically just as the Next.js app will
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+    const expectedHost = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+    // Use request.get instead of page.goto to ensure we get raw text and not wrapped by browser's raw viewer
+    const response = await request.get('/robots.txt')
+    expect(response.ok()).toBeTruthy()
+
+    // The content type should be plain text
+    expect(response.headers()['content-type']).toContain('text/plain')
+
+    const text = await response.text()
+
+    // Check that user-agent is correctly targeted
+    expect(text).toContain('User-Agent: *')
+
+    // Check allow rules
+    expect(text).toContain('Allow: /')
+    expect(text).toContain('Allow: /login')
+
+    // Check disallow rules (private and user-specific routes)
+    expect(text).toContain('Disallow: /dashboard')
+    expect(text).toContain('Disallow: /settings')
+    expect(text).toContain('Disallow: /inventory')
+    expect(text).toContain('Disallow: /luggage')
+    expect(text).toContain('Disallow: /trip/')
+    expect(text).toContain('Disallow: /api/')
+
+    // Check that host is included correctly
+    expect(text).toContain(`Host: ${expectedHost}`)
+  })
+})


### PR DESCRIPTION
💡 **What:** Added a dynamic `app/robots.ts` configuration to generate a `robots.txt` file using Next.js `MetadataRoute.Robots` API. Also added a Playwright test to verify its output.
🎯 **Why:** To explicitly define crawl scopes for search engines, allowing public pages (like `/` and `/login`) to be indexed while blocking private authenticated routes (like `/dashboard`, `/settings`, and `/trip/`) to prevent indexing of user-specific data or redirect loops.
📊 **Impact:** Improves SEO by directing search engine crawlers only to public-facing content, preventing crawl budget waste on private paths and avoiding "indexed, though blocked by robots.txt" warnings for unauthorized redirect pages.
🔬 **Verification:** A Playwright test (`tests/seo.test.ts`) has been added to ensure the `robots.txt` output matches the expected plain-text format, contains the correct `Allow` and `Disallow` rules, and resolves the `Host` accurately based on the environment variables.
🔗 **References:** [Google Search Central - Intro to robots.txt](https://developers.google.com/search/docs/crawling-indexing/robots/intro) and [Next.js robots.txt Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots).

---
*PR created automatically by Jules for task [17543097333756939051](https://jules.google.com/task/17543097333756939051) started by @mvng*