### PR TITLE
🎨 Palette: [UX improvement] Fix keyboard accessibility for trip dashboard actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Fix keyboard accessibility for hover-revealed dashboard actions
+**Learning:** In lists or grids of items (like the Dashboard trip cards), action buttons (edit/delete) are often hidden by default and revealed only on pointer hover (`group-hover:opacity-100`). This completely hides them from keyboard-only users who navigate via the Tab key, and using generic `aria-label`s like "Edit trip" creates a poor screen reader experience when multiple identical buttons are present.
+**Action:** When designing hover-revealed actions, always include `focus-within:opacity-100` on the container so the buttons appear when a child receives focus. Furthermore, add robust focus rings (`focus-visible:ring-2`) and dynamically interpolate the `aria-label` to provide context (e.g., `Edit ${trip.name}`).

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -157,19 +157,19 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 flex gap-1 transition-opacity">
+      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-1 transition-opacity">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center"
-          aria-label="Edit trip"
+          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-white shadow-sm hover:shadow"
+          aria-label={`Edit ${trip.name || trip.destination || 'trip'}`}
         >
           <Edit2 className="w-4 h-4" />
         </button>
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center"
-          aria-label="Delete trip"
+          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 bg-white shadow-sm hover:shadow"
+          aria-label={`Delete ${trip.name || trip.destination || 'trip'}`}
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
         </button>
@@ -200,19 +200,19 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
+      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center"
-          aria-label="Edit trip"
+          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:bg-white"
+          aria-label={`Edit ${trip.name || trip.destination || 'trip'}`}
         >
           <Edit2 className="w-4 h-4" />
         </button>
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center"
-          aria-label="Delete trip"
+          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:bg-white"
+          aria-label={`Delete ${trip.name || trip.destination || 'trip'}`}
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
         </button>


### PR DESCRIPTION
💡 **What:** 
Enhanced the keyboard accessibility and screen-reader experience for the trip action buttons (Edit/Delete) on the Dashboard view.

🎯 **Why:** 
The trip cards featured action buttons that were completely hidden unless the user hovered over the card with a mouse (`group-hover:opacity-100`), making them undiscoverable and unusable for keyboard-only users navigating via the `Tab` key. Furthermore, the `aria-label` on every button read generically as "Edit trip", creating a confusing experience for screen reader users parsing a large list of identical actions without context.

📸 **Before/After:**
- **Before:** Buttons invisible to keyboard navigation; identical generic `aria-label`s.
- **After:** Buttons reveal gracefully when they receive focus (`focus-within:opacity-100`), exhibit explicit outline rings (`focus-visible:ring-2`), and boast dynamic, context-aware `aria-label`s (e.g., `aria-label="Edit Paris Vacation"`).

♿ **Accessibility:**
- Added `focus-within` and `focus-visible` utility classes to support standard keyboard traversal.
- Updated `aria-label` attributes to interpolate the trip's contextual name or destination.

---
*PR created automatically by Jules for task [16529025068285149914](https://jules.google.com/task/16529025068285149914) started by @mvng*