### PR TITLE
🎨 Palette: [UX improvement] Dashboard keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Fix dashboard action buttons keyboard accessibility
+**Learning:** Hover-revealed action buttons on the dashboard (Edit/Delete trips) were inaccessible to keyboard users because they lacked `focus-within:opacity-100` on the container and `focus-visible` outline rings on the buttons themselves.
+**Action:** Always ensure hover-revealed action buttons have `focus-within:opacity-100` on their container, or `focus-visible:opacity-100` on the button directly, along with appropriate `focus-visible:ring` utilities so keyboard users can navigate to and trigger them.

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -157,10 +157,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 flex gap-1 transition-opacity">
+      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-1 transition-opacity">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-lg transition-all flex items-center justify-center"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -168,7 +168,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
@@ -200,10 +200,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
+      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded transition-all flex items-center justify-center"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -211,7 +211,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}


### PR DESCRIPTION
💡 What: Added `focus-within` and `focus-visible` utility classes to the hover-revealed action buttons (Edit and Delete) on the Dashboard's trip cards.
🎯 Why: Previously, these buttons were completely hidden to keyboard-only users navigating the dashboard via tab because their visibility was tied exclusively to pointer hover (`group-hover:opacity-100`).
📸 Before/After: The Edit and Delete buttons now become visible and outline correctly when focused via the keyboard.
♿ Accessibility: Improved keyboard navigation flow for screen readers and power users on the main Dashboard view.

---
*PR created automatically by Jules for task [13372110924847539901](https://jules.google.com/task/13372110924847539901) started by @mvng*