### PR TITLE
🎨 Palette: [UX improvement] Add keyboard accessibility and ARIA labels to TaskCard actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-04-27 - TaskCard Hover Accessibility
+**Learning:** In Next.js/React applications, using JS-based state (`useState`, `onMouseEnter`) for simple hover reveals is an anti-pattern. It creates unnecessary renders and, crucially, breaks keyboard accessibility because the elements remain hidden to users tabbing through the page. Hiding action buttons inside an `opacity-0` container requires careful handling of focus states to ensure those elements become visible upon keyboard navigation.
+**Action:** Always prefer native Tailwind CSS utilities (`group`, `group-hover`, and importantly `focus-within`) for interactive reveals. Ensure icon-only buttons receive `aria-label` attributes and contextual `focus-visible` ring styling so keyboard users can intuitively navigate and interact with dynamically revealed actions.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,23 +20,21 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
+          aria-label={isDone ? "Mark task as incomplete" : "Mark task as complete"}
         >
           {isDone ? <CheckCircle className="w-5 h-5" /> : <Circle className="w-5 h-5" />}
         </button>
@@ -70,18 +67,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
+            aria-label="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
+            aria-label="Delete task"
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
💡 **What:** Refactored the `TaskCard` component to use CSS-based hover states and added keyboard accessibility attributes.
🎯 **Why:** Previously, action buttons (edit, delete) were revealed using React state (`onMouseEnter`), which failed to reveal the buttons for keyboard users tabbing through the interface. Furthermore, the icon-only buttons lacked context for screen readers and visible focus indicators.
📸 **Before/After:** Before, pressing Tab inside a task card would focus invisible buttons without revealing them. Now, tabbing through the card reveals the actions container via `focus-within:opacity-100` and displays clear `focus-visible:ring-2` indicators around the active button.
♿ **Accessibility:** 
- Replaced JS-hover with Tailwind `group-hover` and `focus-within`.
- Added contextual `aria-label`s to the Toggle Status, Edit, and Delete buttons.
- Added `focus-visible` outline rings to ensure keyboard users can track their active element.

---
*PR created automatically by Jules for task [4351501921291024536](https://jules.google.com/task/4351501921291024536) started by @mvng*