### PR TITLE
🎨 Palette: Improve accessibility of icon-only action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2025-02-12 - Ensure icon-only list action buttons are accessible
+**Learning:** Found multiple instances of icon-only action buttons within mapped lists (like Save/Cancel note actions in PackingListSection, and Remove tag in PlanningBoardView) that were completely lacking `aria-label`s and proper `focus-visible` styling, making them difficult for screen reader and keyboard-only users to interpret or navigate.
+**Action:** Always provide descriptive `aria-label` attributes to icon-only action buttons. When working inside loops, dynamically generate labels (e.g., `aria-label={"Delete " + item.name}`) to provide context, and ensure `focus-visible:outline-none focus-visible:ring-2` is applied.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -725,9 +725,10 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         handleUpdateNotes(item.id, item.categoryId, item.packingListId, editingNotes?.notes || "")
                         setEditingNotes(null)
                       }}
-                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      aria-label="Save note"
+                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button onClick={() => setEditingNotes(null)} aria-label="Cancel note editing" className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500"><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -1241,9 +1242,10 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                               handleUpdateNotes(item.id, category.id, list.id, editingNotes?.notes || "")
                                               setEditingNotes(null)
                                             }}
-                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                                            aria-label="Save note"
+                                            className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                                           ><Check className="w-3 h-3" /></button>
-                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                                          <button onClick={() => setEditingNotes(null)} aria-label="Cancel note editing" className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500"><X className="w-3 h-3" /></button>
                                         </div>
                                       </div>
                                     ) : item.notes ? (
@@ -1270,7 +1272,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                     title="Add to departure checklist"
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center"
                                   ><Sunrise className="w-3.5 h-3.5" /></button>
-                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
+                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} aria-label={`Delete ${item.name}`} className="text-red-400 hover:text-red-600 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
                                 </div>
                               )}
                             </li>

--- a/components/PlanningBoardView.tsx
+++ b/components/PlanningBoardView.tsx
@@ -497,7 +497,7 @@ function DayColumn({
               <span className="text-sm">{allDayTag.icon}</span>
               <span className={`text-[11px] font-semibold ${headerText} opacity-90`}>{allDayTag.label}</span>
               <span className={`text-[10px] ml-0.5 opacity-50 ${headerText}`}>— all day</span>
-              <button onClick={() => saveLabel('')} className={`ml-auto text-[11px] opacity-60 hover:opacity-100 ${headerText} focus:outline-none leading-none`}>✕</button>
+              <button onClick={() => saveLabel('')} aria-label="Remove tag" className={`ml-auto text-[11px] opacity-60 hover:opacity-100 ${headerText} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm leading-none`}>✕</button>
             </div>
           ) : editingLabel ? (
             <input autoFocus type="text" value={labelInput}


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes and modernized focus styles (replacing default focus with `focus-visible:ring-2`) to several icon-only action buttons within mapped lists.

🎯 **Why**: During keyboard navigation and screen reader usage, these icon-only buttons (like "Save note", "Cancel", "Delete item", and "Remove tag") lacked readable text and clear visual focus outlines, making them difficult to discover and interact with. 

📸 **Before/After**: 
- *Before*: `<button className="focus:outline-none"><X /></button>`
- *After*: `<button aria-label="Cancel note editing" className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500"><X /></button>`

♿ **Accessibility**: 
- Added dynamically interpolated `aria-label`s when inside mapping loops (e.g., ``aria-label={`Delete ${item.name}`}``).
- Swapped hover/pointer-only action discovery to include `focus-visible` ring utility classes so keyboard-only users can clearly identify interactive elements while tabbing through lists.

---
*PR created automatically by Jules for task [14844134520204982299](https://jules.google.com/task/14844134520204982299) started by @mvng*