### PR TITLE
🔍 Scout: [Add robots.txt and sitemap.xml for crawlability control]

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-04-29 - [Sitemap and Robots Configuration]
+**Learning:** Generating a sitemap.ts in Next.js improves crawlability, but using `lastModified: new Date()` for static routes is an anti-pattern as it inaccurately signals constant content changes. Additionally, robustly trimming trailing slashes from dynamic `NEXT_PUBLIC_APP_URL` prevents malformed `sitemap.xml` double-slash URLs.
+**Action:** When creating SEO configuration files (sitemap/robots), omit `lastModified: new Date()` unless tied to a real database timestamp, strictly validate trailing slashes on base URLs, and clearly comment why specific private paths are disallowed.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,21 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Adding robots.ts generates a robots.txt file that guides search engine crawlers.
+// It allows indexing of public landing pages (/, /login) while explicitly disallowing
+// private, authenticated routes (/dashboard, /settings, /inventory, /luggage) and
+// user-specific shared trip pages (/trip/). This prevents search engines from
+// indexing sensitive user data and hitting auth redirects.
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage', '/trip/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Adding sitemap.ts generates a sitemap.xml file, improving crawlability by
+// explicitly providing search engines with a list of the application's public routes.
+// Private routes and dynamic user-content pages are omitted.
+// Note: We avoid using dynamic `lastModified: new Date()` as it inaccurately tells
+// search engines the content changes on every request/build for static pages.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      changeFrequency: 'weekly',
+      priority: 1.0,
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('SEO Configuration', () => {
+  test('robots.txt should have the correct configuration', async ({ request }) => {
+    const response = await request.get('/robots.txt')
+    expect(response.status()).toBe(200)
+
+    const text = await response.text()
+
+    // Check for user-agent
+    expect(text).toContain('User-Agent: *')
+
+    // Check allows and disallows
+    expect(text).toContain('Allow: /')
+    expect(text).toContain('Allow: /login')
+    expect(text).toContain('Disallow: /dashboard')
+    expect(text).toContain('Disallow: /settings')
+    expect(text).toContain('Disallow: /inventory')
+    expect(text).toContain('Disallow: /luggage')
+    expect(text).toContain('Disallow: /trip/')
+
+    // Verify sitemap link dynamically
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+    const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+    expect(text).toContain(`Sitemap: ${baseUrl}/sitemap.xml`)
+  })
+
+  test('sitemap.xml should include public routes', async ({ request }) => {
+    const response = await request.get('/sitemap.xml')
+    expect(response.status()).toBe(200)
+
+    const text = await response.text()
+
+    // Verify it is XML
+    expect(text).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(text).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">')
+
+    const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+    const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+    // Check for homepage
+    expect(text).toContain(`<loc>${baseUrl}/</loc>`)
+
+    // Check for login page
+    expect(text).toContain(`<loc>${baseUrl}/login</loc>`)
+  })
+})


### PR DESCRIPTION
💡 **What:** Added `robots.ts` and `sitemap.ts` to programmatically generate `robots.txt` and `sitemap.xml`.
🎯 **Why:** Search engine crawlers need explicit maps of public routes and restrictions on private, dynamic paths to optimize crawl budgets and prevent accidental indexing of auth redirects or user dashboards.
📊 **Impact:** Improves visibility for the homepage and login page while cleanly blocking crawler access to user-specific trip data (`/trip/[id]`) and authenticated state paths (`/dashboard`).
🔬 **Verification:** Validated via automated Playwright tests fetching the generated `/robots.txt` and `/sitemap.xml` routes. You can verify manually using the Next.js local dev server.
🔗 **References:** [Next.js Metadata Files Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

---
*PR created automatically by Jules for task [15877812786167983179](https://jules.google.com/task/15877812786167983179) started by @mvng*