### PR TITLE
🎨 Palette: [UX] Improve accessibility of trip member avatars

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Fix focus-visible inside groups
+**Learning:** Found that `group-focus-visible` does not reliably trigger visibility toggles (e.g., `group-focus-visible:block`) on child elements when the parent `.group` button receives focus in this project's Tailwind setup.
+**Action:** Use `group-focus-within` (e.g., `group-focus-within:block` and `group-focus-within:hidden`) on child elements to correctly update their visual state when the parent `.group` element receives keyboard focus.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,16 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
-              title={member.name}
+              aria-label={isOwner ? `Remove member ${member.name}` : `Member ${member.name}`}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}


### PR DESCRIPTION
💡 What: Added `aria-label` to member avatars and ensured proper focus states for keyboard navigation.
🎯 Why: The previous implementation relied on `title` attributes and `group-hover` for the close button and tooltip, making it completely inaccessible to keyboard users and screen readers.
📸 Before/After: Avatars can now be tabbed to, with a visible focus ring. The tooltip and "X" close icon appear reliably on focus as well.
♿ Accessibility: Uses `aria-label` for proper description, `focus-visible:ring` for clear focus outlines, and `group-focus-within` to toggle child icon visibility without relying purely on pointer hover states.

---
*PR created automatically by Jules for task [5383222423768240811](https://jules.google.com/task/5383222423768240811) started by @mvng*