### PR TITLE
🔍 Scout: [SEO improvement] Add robots.txt and sitemap.xml to manage crawl budget

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-05-01 - [Sitemap and Crawl Budget Anti-patterns]
+**Learning:** When generating a `sitemap.ts` in Next.js, avoid using `lastModified: new Date()` for static routes. This is an anti-pattern that inaccurately signals to search engines that the content has changed upon every request/build, which can unnecessarily consume crawl budget.
+**Action:** Use a fixed date for `lastModified` on static routes to accurately reflect when the core content was actually updated, and ensure trailing slashes from base URLs are safely stripped when constructing SEO routes to prevent double slashes.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,30 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  // SCOUT SEO RATIONALE:
+  // We explicitly define crawling rules to optimize the crawl budget and prevent
+  // search engines from indexing private or user-specific pages.
+  // Public routes (/, /login) are allowed.
+  // Authenticated app routes (/dashboard, /settings, /inventory, /luggage) and
+  // user-specific shared trip pages (/trip/) are disallowed to protect privacy
+  // and prevent index bloat from thin or inaccessible pages.
+
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: [
+        '/dashboard',
+        '/settings',
+        '/inventory',
+        '/luggage',
+        '/trip/',
+        '/api/' // typically we disallow api routes as well
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,28 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // SCOUT SEO RATIONALE:
+  // Generating a sitemap.xml to help search engines easily discover our public pages.
+  // We only include the static public routes (/ and /login) which are relevant for indexing.
+  // We use a fixed lastModified date for static pages instead of `new Date()`
+  // to prevent falsely signaling content changes on every build/request,
+  // which is an SEO anti-pattern that can dilute crawl budget.
+
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: new Date('2024-05-01T00:00:00.000Z'), // Fixed date for static content
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date('2024-05-01T00:00:00.000Z'), // Fixed date for static content
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** Added Next.js `app/robots.ts` and `app/sitemap.ts` to programmatically generate `robots.txt` and `sitemap.xml`.
🎯 **Why:** To improve crawlability for public pages (`/` and `/login`) while explicitly preventing search engines from indexing private application routes (like `/dashboard` and `/trip/`), which saves crawl budget and prevents index bloat.
📊 **Impact:** Enables better discoverability of the landing page on search engines while protecting user-specific routes from being crawled or flagged as thin content.
🔬 **Verification:** Verify that `https://<domain>/robots.txt` and `https://<domain>/sitemap.xml` are correctly generated and contain the expected rules.
🔗 **References:** [Next.js SEO Documentation](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

---
*PR created automatically by Jules for task [7242306635993484213](https://jules.google.com/task/7242306635993484213) started by @mvng*