### PR TITLE
⚡ Bolt: [performance improvement] optimize PlanningBoardView array search and date rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2025-03-18 - Nested array searching inside React render loop
+**Learning:** In React components dealing with large lists (like `PlanningBoardView` dealing with packing items and day plan items), calculating derived state using nested array methods (e.g. `array1.filter(item => array2.some(...))`) during a `useEffect` or render cycle causes $O(N \times M)$ time complexity which can significantly lag the UI when item counts grow. Additionally, mapping arrays of standard primitive objects like Dates inside the render loop without `useMemo` triggers unnecessary garbage collection and potentially cascading effects.
+**Action:** When deriving state from multiple arrays, always convert the array being searched into a `Set` first for $O(1)$ lookups, bringing the complexity down to $O(N + M)$. Always wrap expensive loop or date object creations in `useMemo` to preserve reference equality across renders.

--- a/components/PlanningBoardView.tsx
+++ b/components/PlanningBoardView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useTransition, useCallback } from 'react'
+import { useState, useEffect, useTransition, useCallback, useMemo } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import {
   DndContext,
@@ -737,7 +737,10 @@ function TimeSlot({
 // ─── PlanningBoardView ────────────────────────────────────────────────────────
 
 export default function PlanningBoardView({ trip, onUnsyncedItemsChange }: PlanningBoardViewProps) {
-  const days = generateDays(trip.startDate, trip.endDate)
+  // ⚡ Bolt Performance Optimization
+  // Why: Prevents expensive Date instantiations on every render.
+  // Impact: Avoids array reconstruction and mapping when unrelated state changes occur.
+  const days = useMemo(() => generateDays(trip.startDate, trip.endDate), [trip.startDate, trip.endDate])
   const [dayPlans, setDayPlans] = useState<DayPlanMap>({})
   const [activeId, setActiveId] = useState<string | null>(null)
   const [tagOverColumn, setTagOverColumn] = useState<string | null>(null)
@@ -751,10 +754,15 @@ export default function PlanningBoardView({ trip, onUnsyncedItemsChange }: Plann
     const allPlanItems = Object.values(dayPlans).flatMap(dp => dp.items || [])
     const packingItems = trip.packingLists?.flatMap((list: any) => list.categories.flatMap((cat: any) => cat.items)) || []
 
+    // ⚡ Bolt Performance Optimization
+    // Why: Replaces O(n) array `.some()` inside `.filter()` with an O(1) Set lookup.
+    // Impact: Improves unsynced item calculation time complexity from O(n²) to O(n), crucial for trips with many items.
+    const packingNames = new Set(packingItems.map((pi: any) => pi.name.toLowerCase()))
+
     const unsyncedItems = allPlanItems
       .filter(planItem => {
         if (planItem.category === TAG_CATEGORY) return false
-        return !packingItems.some((pi: any) => pi.name.toLowerCase() === planItem.name.toLowerCase())
+        return !packingNames.has(planItem.name.toLowerCase())
       })
       .map(item => item.name)
 


### PR DESCRIPTION
### 💡 What
Optimized the `PlanningBoardView` component by:
1. Wrapping the `generateDays` helper function call in a `useMemo` hook so the array of `Date` objects is only calculated when the trip's start or end dates change.
2. Refactoring the `unsyncedItems` calculation inside the `useEffect` to construct a `Set` of lowercase packing item names first, and then using `.has()` inside the `.filter()` loop. 

### 🎯 Why
Previously, `generateDays` instantiated a new Date array on every render, causing unnecessary allocations and garbage collection overhead. Furthermore, the `unsyncedItems` calculation checked if an item existed in `packingItems` using `.some()` nested inside `.filter()`. This resulted in an $O(N \times M)$ time complexity where $N$ is the number of day plan items and $M$ is the number of packing items. For large trips, this could cause noticeable UI lag during drag-and-drop operations or state updates. Using a `Set` brings the complexity down to $O(N + M)$ for $O(1)$ lookups.

### 📊 Impact
- Reduces rendering overhead by preserving array/Date references via `useMemo`.
- Vastly improves the execution speed of the unsync item sync `useEffect` from $O(N \times M)$ to $O(N)$. For example, a trip with 50 packing items and 50 day plan items previously required up to 2,500 comparisons; it now requires roughly 100 string manipulations and lookups.

### 🔬 Measurement
Verified the logic using `read_file` to inspect the patch. `pnpm lint` confirms there are no ESLint issues or missing dependencies (e.g. `useMemo` was imported properly). All tests related to the modified components (`pnpm test`) pass cleanly.

---
*PR created automatically by Jules for task [15577693639815288837](https://jules.google.com/task/15577693639815288837) started by @mvng*