### PR TITLE
🎨 Palette: [UX improvement] Improve accessibility and keyboard navigation in TripMembersSection

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Group focus-within for nested hover/focus visibility
+**Learning:** In this project's Tailwind setup, relying on `group-focus-visible` for revealing nested hidden elements (like tooltips or secondary actions inside a button group) during keyboard navigation does not consistently cascade to child elements.
+**Action:** When creating components where elements are hidden and only revealed on interaction, use `group-focus-within` on the parent container alongside `group-hover` to toggle visibility of child elements (e.g., `group-focus-within:block`, `group-focus-within:opacity-100`) to ensure keyboard users trigger the same visible states as mouse users.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,8 +85,9 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 flex items-center justify-center transition-colors"
             title="Add member"
+            aria-label="Add new member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -110,15 +112,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors"
             title="Confirm"
+            aria-label="Confirm adding member"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 transition-colors"
             title="Cancel"
+            aria-label="Cancel adding member"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
### 💡 What
Added missing `aria-label`s to icon-only buttons (Remove, Add, Confirm, Cancel) in the `TripMembersSection` component. Added explicit `focus-visible` utility classes (e.g., `focus-visible:ring-2 focus-visible:ring-blue-500`) to ensure clear visual focus rings during keyboard navigation. Additionally, updated the member avatar pills to utilize `group-focus-within` to reveal tooltips and remove icons, which were previously completely hidden from keyboard users relying solely on mouse hover states.

### 🎯 Why
To ensure the Trip Members section is fully accessible to screen reader and keyboard-only users. Prior to these changes, interactive icon buttons lacked accessible names, preventing screen readers from conveying their purpose. Keyboard navigators were also unable to discover the member names or access the 'remove' action because the tooltips and 'X' icons were gated behind `group-hover` pointer events.

### 📸 Before/After
*(Visual verification screenshots and videos attached in pre-commit hooks)*
**Before**: Tabbing to a user avatar provided no visual indicator, tooltip, or way to access the 'Remove' state. Icon buttons lacked `aria-label`s.
**After**: Tabbing to a user avatar clearly outlines the button with a blue ring, reveals the user's name tooltip, and reveals the 'X' remove icon. All icon-only buttons are now screen reader friendly.

### ♿ Accessibility
- Added `aria-label` to four distinct icon-only buttons.
- Ensured consistent keyboard focus indicators via `focus-visible`.
- Migrated hover-dependent UI discovery to `group-focus-within` for keyboard parity.

---
*PR created automatically by Jules for task [1520913073481965299](https://jules.google.com/task/1520913073481965299) started by @mvng*