### PR TITLE
🎨 Palette: Enhance TaskCard keyboard accessibility and screen reader support

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Replace JS-based hover states with CSS for accessibility
+**Learning:** Found that `TaskCard.tsx` was using `onMouseEnter` / `onMouseLeave` state (`isHovered`) to conditionally render action buttons. This completely hid the Edit and Delete buttons from keyboard users.
+**Action:** Always prefer native Tailwind CSS `group`, `group-hover`, and importantly, `focus-within` utilities instead of JavaScript state for hover-revealed elements. This ensures keyboard users can access actions when tabbing through the interface, while also improving render performance.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react'
-import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
+import { Calendar, Trash2, Edit2, CheckCircle, Circle } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
 interface TripTask {
@@ -21,21 +20,19 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`relative p-4 rounded-xl border transition-all group ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? `Mark "${task.title}" as incomplete` : `Mark "${task.title}" as complete`}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full transition-colors ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,17 +67,19 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            aria-label={`Edit "${task.title}"`}
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors"
             title="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            aria-label={`Delete "${task.title}"`}
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 transition-colors"
             title="Delete task"
           >
             <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
💡 **What**: Refactored `TaskCard.tsx` to use native Tailwind CSS (`group-hover`, `focus-within`) instead of JavaScript state for revealing the Edit and Delete actions. Added explicit `focus-visible` outline rings to all interactive buttons and attached descriptive `aria-label` attributes to the icon-only elements (Toggle, Edit, Delete). Also updated the `.jules/palette.md` journal with this learning.

🎯 **Why**: The previous implementation completely hid the Edit and Delete buttons from keyboard-only users because the elements were only revealed via mouse events (`onMouseEnter`). Furthermore, screen readers could not properly announce the purpose of the icon-only buttons.

📸 **Before/After**:
- **Before**: Edit/Delete buttons were invisible to keyboard navigation. Hover required JS state updates. Buttons lacked `aria-label`s.
- **After**: Edit/Delete buttons appear when the card or the buttons themselves receive keyboard focus. Tabbing creates clear visual focus rings. Screen readers now announce the specific task being edited, deleted, or completed.

♿ **Accessibility**:
- Replaced pointer-event dependency with CSS `focus-within`.
- Added high-contrast `focus-visible:ring-2` to buttons.
- Added contextual `aria-label`s (e.g., `Edit "Renew passport"`).

---
*PR created automatically by Jules for task [10386224781554044885](https://jules.google.com/task/10386224781554044885) started by @mvng*