### PR TITLE
🎨 Palette: Enhance accessibility in Trip Members section

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Enhance TripMembersSection accessibility
+**Learning:** Found that the "Remove Member" button in the member pills relied on `group-hover` to show the 'X' icon and tooltip, rendering it inaccessible to keyboard users tabbing through the list.
+**Action:** Always ensure hover-revealed action buttons or elements include `group-focus-within` styles (e.g., `group-focus-within:block` and `group-focus-within:opacity-100`) alongside proper `focus-visible` outline rings so screen reader and keyboard users can discover and interact with them.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-blue-500 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={`Remove ${member.name}`}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,7 +85,7 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
@@ -110,14 +111,14 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Confirm"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Cancel"
           >
             <X className="w-3.5 h-3.5" />


### PR DESCRIPTION
💡 **What**: The UX enhancement added keyboard focus styles (`focus-visible:ring-2`) to all interactive buttons (Add, Remove, Confirm, Cancel) in the `TripMembersSection`. It also added an `aria-label` to the icon-only "Remove member" button and utilized `group-focus-within` to ensure the dynamically revealed 'X' icon and tooltip are discoverable by keyboard-only users.
🎯 **Why**: Previously, the "Remove member" functionality relied exclusively on a mouse `hover` state (`group-hover:hidden`, `group-hover:block`), making it entirely invisible and undiscoverable to users navigating via keyboard. Additionally, the icon-only layout lacked descriptive ARIA attributes, creating a poor experience for screen readers.
📸 **Before/After**: 
*Before*: Buttons lacked focus rings. The member 'X' icon and name tooltip only appeared on mouse hover.
*After*: Tabbing through the section highlights buttons with a blue focus ring. Focusing on a member pill correctly reveals the 'X' icon and the tooltip.
♿ **Accessibility**: 
- Added `aria-label={\`Remove \${member.name}\`}` to icon-only buttons.
- Leveraged `group-focus-within` to surface hidden contextual actions.
- Enforced `focus-visible:outline-none focus-visible:ring-2` styling on interactive elements.

---
*PR created automatically by Jules for task [911900013171996468](https://jules.google.com/task/911900013171996468) started by @mvng*