### PR TITLE
🎨 Palette: [Make hover-revealed tooltips and actions accessible to keyboards]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Fix missing keyboard accessibility for hover-revealed tooltips and actions
+**Learning:** Found a pattern where custom tooltips and secondary actions (like 'Remove' buttons) rely solely on `group-hover:opacity-100` and lack focus rings, making them inaccessible to keyboard users and screen readers navigating via the Tab key.
+**Action:** Always complement `group-hover:opacity-100` with `group-focus-within:opacity-100` or `focus-visible:opacity-100` for interactive elements to ensure they are revealed during keyboard navigation, and utilize `focus-visible:ring-2` to clearly outline the focused element. Also ensure custom tooltips on interactive elements replace native titles with descriptive `aria-label` attributes to prevent conflicting screen reader announcements.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -865,7 +865,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         {itemCount > 0 && <span className="text-xs text-gray-500">({itemCount})</span>}
                         <button
                           onClick={() => handleRemoveLuggage(tl.id, tl.luggageId)}
-                          className="ml-1 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"
+                          className="ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-gray-400 hover:text-red-500 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded px-1 flex items-center"
                           aria-label={`Remove ${tl.luggage.name}`}
                         ><X className="w-3.5 h-3.5" /></button>
                       </div>

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,16 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
-                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-all ${
+                isOwner ? 'hover:bg-red-100 hover:text-red-600 focus-visible:bg-red-100 focus-visible:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
-              title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}


### PR DESCRIPTION
### 💡 What
Added keyboard and screen reader accessibility to custom hover-revealed tooltips and icon-buttons inside the Trip Members and Packing List sections.

### 🎯 Why
Custom tooltips and secondary actions (like 'Remove' buttons) were only relying on CSS `group-hover:opacity-100`. This completely locked out users who navigate the interface using their keyboard (`Tab` key), as elements never received a visible focus state or came into view.

Additionally, native `title` attributes on these tooltips competed with the custom UI visual, causing redundant screen reader announcements.

### 📸 Before/After
*   **Before:** Tabbing into the Trip Members section focused the avatar pill but revealed nothing. The 'remove luggage' 'X' button on the packing list remained invisible during keyboard navigation.
*   **After:** Tabbing gracefully reveals the tooltip (with proper focus rings) and makes hover-only actions visible via `focus-visible` utilities.

### ♿ Accessibility
*   Swapped generic `title` attributes for contextual `aria-label`s.
*   Ensured focus indicators only appear for keyboard users (`focus-visible:ring-2`) to avoid regressing the mouse experience.
*   Leveraged `group-focus-within` to bring child tooltips onto the screen during active keyboard focus.

---
*PR created automatically by Jules for task [18060004734894660744](https://jules.google.com/task/18060004734894660744) started by @mvng*