### PR TITLE
🔍 Scout: [Added sitemap and robots.txt]

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-03-15 - [Sitemap and Robots Configuration]
+**Learning:** Next.js App Router natively supports `robots.ts` and `sitemap.ts` files to programmatically define SEO configurations. When generating URLs utilizing environment variables like `process.env.NEXT_PUBLIC_APP_URL`, it is vital to safely trim trailing slashes to avoid double-slash URL formations (e.g., `https://example.com//route`). Furthermore, deliberately disallowing private routes (e.g., `/dashboard`, `/settings`) within `robots.ts` is essential to prevent crawler leakages and conserve crawl budgets.
+**Action:** Always employ programmatic `robots.ts` and `sitemap.ts` files in Next.js to govern crawl budgets explicitly, ensuring proper string manipulation for URLs constructed from base environment variables.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,18 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SEO Rationale:
+  // - Public routes like / and /login are allowed for indexing.
+  // - Private authenticated routes (/dashboard, /settings, /inventory, /luggage) and user-specific shared trips (/trip/) are disallowed to prevent exposing private data and conserve crawl budget.
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage', '/trip/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SEO Rationale:
+  // - We include public routes (/ and /login) to ensure search engine discovery.
+  // - We deliberately exclude private routes to prevent indexing of restricted content.
+  // - We avoid `lastModified: new Date()` for static routes to accurately reflect content freshness.
+  return [
+    {
+      url: `${baseUrl}/`,
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** Added programmatic `sitemap.ts` and `robots.ts` to the Next.js App Router using native `MetadataRoute` definitions.
🎯 **Why:** To guide search engines properly, ensuring they discover public pages (like `/` and `/login`) while strictly preventing them from indexing or wasting crawl budget on private authenticated routes (`/dashboard`, `/settings`, `/inventory`, `/luggage`, `/trip/`).
📊 **Impact:** Improves overall SEO crawlability and efficiency. It ensures search engines only index intended landing pages and avoids generating soft 404s or exposing private URLs.
🔬 **Verification:** Verified files render valid sitemap XML and robots.txt syntax. Ensured no regressions by running tests (`pnpm test`) and linting (`pnpm lint`).
🔗 **References:** [Next.js Sitemap docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap), [Next.js Robots docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

---
*PR created automatically by Jules for task [8901603953572001017](https://jules.google.com/task/8901603953572001017) started by @mvng*