### PR TITLE
🎨 Palette: Enhance accessibility of TripMembersSection tooltips and buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve keyboard accessibility on hover-revealed tooltips in list components
+**Learning:** Found a pattern where custom CSS tooltips or secondary visual states (like the "X" for remove on member avatars) are tied exclusively to `group-hover`. This makes the state and the tooltip text completely invisible to keyboard-only users who navigate via <kbd>Tab</kbd> and use `focus` states.
+**Action:** Always complement `group-hover:block` and `group-hover:opacity-100` classes with `group-focus-within:block` and `group-focus-within:opacity-100` on interactive elements to ensure visual parity for keyboard users.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,16 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
-              title={member.name}
+              aria-label={member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,8 +84,8 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
-            title="Add member"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+            aria-label="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -110,15 +110,15 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
-            title="Confirm"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+            aria-label="Confirm"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
-            title="Cancel"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+            aria-label="Cancel"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
### 💡 What
This PR adds small but crucial accessibility and keyboard navigation enhancements to the `TripMembersSection` component.
- `title` attributes on the member avatars, "Add", "Confirm", and "Cancel" icon-only buttons were replaced with standard `aria-label`s.
- `focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400` classes were added to all interactive elements to ensure visual focus rings appear when navigating via keyboard (tabbing).
- `group-focus-within:block`, `group-focus-within:hidden`, and `group-focus-within:opacity-100` classes were added to the member avatar groups.

### 🎯 Why
Native `title` attributes on buttons often cause double announcements for screen readers and provide clunky default hover delays. Semantic `aria-label`s are the best practice for icon-only inputs. More importantly, hover-revealed features (like the tooltip showing the member's name and the "X" removal button) were previously hidden from keyboard-only users who navigate the interface using the `Tab` key. Utilizing `group-focus-within` ensures visual parity and accessibility for all users.

### 📸 Before/After
*(Visual verification was captured demonstrating the new blue focus-rings and revealed tooltips when tabbing through the member pill and add-member controls).*

### ♿ Accessibility
- Screen readers now correctly read the intended button label without redundant tooltip noise.
- Keyboard-only users can now discover and interact with the remove member "X" button and read member name tooltips.
- Focus visibility conforms to accessibility standards.

---
*PR created automatically by Jules for task [3860708356774136163](https://jules.google.com/task/3860708356774136163) started by @mvng*