### PR TITLE
🔍 Scout: [Dynamic Sitemap and Robots generation]

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2025-05-06 - [Next.js App Router Dynamic Sitemaps and Robots]
+**Learning:** Next.js App Router natively supports generating dynamic `sitemap.xml` and `robots.txt` files by creating `sitemap.ts` and `robots.ts` in the root `app/` directory. These files can programmatically determine which routes to expose or block, such as explicitly excluding private dashboard routes from search crawlers to optimize crawl budget.
+**Action:** When working on a Next.js App Router project, always verify the presence of `sitemap.ts` and `robots.ts`. If missing, generate them dynamically to ensure search engines only crawl intended public pages, rather than relying on static `.xml` or `.txt` files that might drift from the application's actual structure.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,21 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Generating a dynamic robots.txt directs search engine crawlers on which pages to index.
+// We allow crawling of public landing and authentication pages (`/` and `/login`) to ensure
+// they appear in search results. Conversely, we explicitly disallow crawling of private routes
+// (`/dashboard`, `/settings`, `/inventory`, `/luggage`) and user-specific shared paths (`/trip/`)
+// to preserve data privacy, prevent duplicate content penalties, and optimize crawl budget.
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage', '/trip/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,27 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Generating a dynamic sitemap.xml ensures search engines can easily discover and crawl
+// the public-facing pages of Packwise (`/` and `/login`). We explicitly prioritize the homepage
+// with a higher weight (1.0) compared to the login page (0.8). Private authenticated routes
+// and user-specific shared pages are intentionally excluded from this sitemap to prevent
+// them from being indexed and cluttering search results with inaccessible or private content.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1.0,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:**
Added `app/sitemap.ts` and `app/robots.ts` to dynamically generate `sitemap.xml` and `robots.txt` using Next.js App Router native MetadataRoute APIs. The sitemap includes public pages (`/` and `/login`) with appropriate priorities. The `robots.txt` explicitly allows public routes while disallowing private, authenticated routes (like `/dashboard`, `/settings`, `/inventory`, `/luggage`) and user-specific shared paths (`/trip/`).

🎯 **Why:**
Previously, Packwise lacked explicit instructions for search engine crawlers. Without a `robots.txt` and `sitemap.xml`, crawlers might waste budget attempting to access blocked private routes, leading to soft 404s or potential duplicate content issues. Providing a dynamic sitemap ensures search engines discover the public landing page efficiently, and blocking private routes protects user privacy while optimizing the crawl budget.

📊 **Impact:**
- Ensures `https://packwise-indol.vercel.app/` and `/login` are easily discoverable and crawled efficiently.
- Prevents search engines from indexing and displaying private user dashboard or shared trip pages in search results.
- Improves overall site technical SEO hygiene and crawl budget optimization.

🔬 **Verification:**
1. Run `pnpm dev`.
2. Navigate to `http://localhost:3000/sitemap.xml` and verify it renders XML containing the `/` and `/login` routes with priorities.
3. Navigate to `http://localhost:3000/robots.txt` and verify the `User-Agent`, `Allow`, and `Disallow` rules are correctly listed, along with the `Sitemap` URL.
4. Linters (`pnpm lint`) and tests (`pnpm test`) have passed, ensuring no regressions.

🔗 **References:**
- Next.js Metadata Files: [sitemap.xml](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)
- Next.js Metadata Files: [robots.txt](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)
- Google Search Central: [Intro to robots.txt](https://developers.google.com/search/docs/crawling-indexing/robots/intro)

---
*PR created automatically by Jules for task [424191643772996191](https://jules.google.com/task/424191643772996191) started by @mvng*