### PR TITLE
🎨 Palette: Enhance TaskCard keyboard accessibility and replace JS hover with CSS

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Enhance TaskCard keyboard accessibility and replace JS hover with CSS
+**Learning:** React state-based hover reveals (`onMouseEnter`/`onMouseLeave`) completely break keyboard navigation for screen reader and tab-only users because the action elements are missing from the focus order when not hovered.
+**Action:** Replace `useState` hover tracking with CSS `group`, `group-hover:opacity-100`, and crucially `focus-within:opacity-100` alongside `focus-visible` styling to ensure interactive sub-elements are fully keyboard-accessible and performant without JavaScript overhead.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,22 +20,20 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
-            isDone ? 'text-green-500 hover:text-green-600' : ''
+          aria-label={isDone ? `Mark "${task.title}" as incomplete` : `Mark "${task.title}" as complete`}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
+            isDone ? 'text-green-500 hover:text-green-600 focus-visible:ring-green-500' : ''
           }`}
         >
           {isDone ? <CheckCircle className="w-5 h-5" /> : <Circle className="w-5 h-5" />}
@@ -70,18 +67,18 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
-            title="Edit task"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:opacity-100"
+            aria-label={`Edit task "${task.title}"`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
-            title="Delete task"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:opacity-100"
+            aria-label={`Delete task "${task.title}"`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
💡 **What:** 
- Replaced JavaScript-based hover state tracking (`onMouseEnter`/`onMouseLeave`) with native Tailwind CSS utilities (`group`, `group-hover:opacity-100`, `focus-within:opacity-100`).
- Replaced native `title` attributes with semantic `aria-label` attributes on icon-only edit/delete/toggle buttons.
- Added `focus-visible:outline-none focus-visible:ring-2` utility classes for explicit keyboard focus outlines.
- Added dynamic screen reader labels for toggling the task's completion status.

🎯 **Why:** 
Previously, the action buttons (edit/delete) were tied entirely to pointer hover events managed by React state. This meant that keyboard users navigating via the Tab key could completely miss the actions because they weren't visible or easily discoverable. Relying on CSS `focus-within` guarantees the actions appear when a keyboard user tabs to them, while `aria-label`s provide essential context for screen readers that the `title` attribute often lacks.

📸 **Before/After:**
*(Visual demonstration available in local verification artifacts, highlighting the blue focus ring on tab-selection).*

♿ **Accessibility:**
- Ensures icon-only buttons clearly announce their purpose (e.g. `Edit task "Book Flights"`).
- Restores keyboard discoverability for primary actions.
- Provides distinct focus rings visible *only* on keyboard navigation (`focus-visible`).

---
*PR created automatically by Jules for task [1330349736164124681](https://jules.google.com/task/1330349736164124681) started by @mvng*