### PR TITLE
🔍 Scout: Add dynamic robots.txt and sitemap.xml

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,28 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// This robots.txt explicitly controls crawler access. We allow crawling of
+// public pages (/ and /login) to ensure they are discoverable in search results.
+// We explicitly disallow private authenticated routes (/dashboard, /settings,
+// /inventory, /luggage) and user-specific shared pages (/trip/, /claim/)
+// to prevent sensitive user data from being indexed and avoid "thin content" penalties.
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: [
+        '/dashboard',
+        '/settings',
+        '/inventory',
+        '/luggage',
+        '/trip/',
+        '/claim/'
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Implementing a dynamic sitemap.xml ensures search engines can efficiently
+// discover and index our core public pages. We prioritize the homepage
+// for frequent crawling. Private pages are deliberately excluded to focus
+// crawl budget on high-value public content.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** Added `app/robots.ts` and `app/sitemap.ts` to utilize Next.js App Router's native Metadata API for generating `robots.txt` and `sitemap.xml` files.
🎯 **Why:** To guide search engine crawlers efficiently. `robots.txt` ensures that private authenticated routes (like `/dashboard`, `/settings`, `/trip/`, etc.) are not crawled, avoiding "thin content" or sensitive data indexing. `sitemap.xml` ensures that the core public pages (`/` and `/login`) are easily discoverable and crawled regularly.
📊 **Impact:** Improves overall crawlability and prevents potential duplicate or thin content penalties. Ensures search engine crawl budget is spent effectively on landing pages.
🔬 **Verification:** 
1. `pnpm run build` and access `/robots.txt` and `/sitemap.xml`.
2. Playwright test `tests/seo.test.ts` confirmed the routes returned expected text output.
🔗 **References:** 
- [Next.js App Router robots.txt](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)
- [Next.js App Router sitemap.xml](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [4657627373185710028](https://jules.google.com/task/4657627373185710028) started by @mvng*