### PR TITLE
🎨 Palette: Add accessibility to TripMembersSection

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improved TripMembersSection accessibility
+**Learning:** Found an issue pattern in `TripMembersSection` where dynamically generated avatar buttons for trip members had no accessible names (only hover tooltips), and hover actions lacked keyboard focus management.
+**Action:** Always ensure dynamic user-avatar buttons have `aria-label` attributes for screen readers, and add `focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1` to ensure they are keyboard navigable and visibly focusable.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,16 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
-              title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,7 +84,8 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
+            aria-label="Add member"
             title="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
@@ -100,6 +101,7 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
             value={newName}
             onChange={e => setNewName(e.target.value)}
             placeholder="Name (e.g. Peter, Grandma)"
+            aria-label="New member name"
             className="text-xs px-2.5 py-1.5 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white w-48"
             onKeyDown={e => {
               if (e.key === 'Enter') handleAdd()
@@ -110,14 +112,16 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
+            aria-label="Confirm adding member"
             title="Confirm"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            aria-label="Cancel adding member"
             title="Cancel"
           >
             <X className="w-3.5 h-3.5" />


### PR DESCRIPTION
💡 What: Added comprehensive keyboard accessibility and screen reader support to `TripMembersSection`. Specifically, user avatar buttons now have dynamic `aria-label`s and `focus-visible` states that reveal custom tooltips via `group-focus-within`. Additionally, the inline "Add member", "Confirm", and "Cancel" icon-only buttons received descriptive `aria-label`s and `focus-visible` treatments, with original `title` attributes retained for sighted hover users.

🎯 Why: Interactive elements mapped from dynamic data or revealed on hover often lack explicit `aria-label`s and `focus-visible` utilities, effectively hiding core functionality (like removing trip members) from visually impaired and keyboard-only users.

📸 Before/After: 
*   **Before:** Avatar buttons had a `title` but no explicit `aria-label` for screen readers, and no outline ring when tab-navigated. The tooltip generated by hovering over a member was invisible to keyboard users. Action icons in the member addition form had `title` attributes but no explicit `aria-label`s and incomplete focus states.
*   **After:** Avatar buttons have full `aria-label` support describing their primary action based on the user's role. Tabbing onto an avatar now reveals an accessible ring *and* triggers the member's custom visual tooltip and "remove" icon via `group-focus-within`.

♿ Accessibility: Ensures WCAG compliance by explicitly naming dynamically generated form buttons and providing highly visible focus rings across the component, allowing robust non-pointer discovery of interactive areas.

---
*PR created automatically by Jules for task [3722345168227394107](https://jules.google.com/task/3722345168227394107) started by @mvng*