### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons in TripMembersSection

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Add accessible labels to TripMembersSection buttons
+**Learning:** Found that the member list buttons in TripMembersSection only used standard `title` attributes for tooltips, and the Add/Confirm/Cancel actions were icon-only without proper screen reader labels (`aria-label`).
+**Action:** Always ensure that avatar buttons or icon-only inline actions have explicit `aria-label`s and proper `focus-visible` utility classes, so screen reader users can identify them and keyboard users can navigate to them clearly.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,10 +58,11 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus-visible:outline-none focus-visible:ring-red-400 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
               <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
               {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
@@ -84,8 +85,9 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Add member"
+            aria-label="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -110,15 +112,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Confirm"
+            aria-label="Confirm"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500"
             title="Cancel"
+            aria-label="Cancel"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes and `focus-visible` utility classes to the icon-only buttons (member avatars, 'Add member', 'Confirm', and 'Cancel') in the `TripMembersSection` component.
🎯 Why: To ensure that these interactive elements are properly announced by screen readers and clearly highlighted when navigated via keyboard.
📸 Before/After: Visual changes include a distinct focus ring around the buttons when accessed via keyboard tab navigation.
♿ Accessibility: Improved keyboard navigation with explicit focus states (`focus-visible:ring-red-400`, `focus-visible:ring-blue-500`, etc.) and enhanced screen reader support for icon-only actions.

---
*PR created automatically by Jules for task [11124326866128067426](https://jules.google.com/task/11124326866128067426) started by @mvng*