### PR TITLE
🎨 Palette: Enhance keyboard accessibility on dashboard trip cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Enhance Dashboard Trip Cards accessibility
+**Learning:** Found that secondary action buttons (like Edit/Delete on trip cards) revealed on hover often lack keyboard focus management and visibility when focused since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
+**Action:** Always ensure hover-revealed action containers and buttons include explicit `focus-within:opacity-100` and `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them visually.

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -119,7 +119,7 @@ export default function DashboardClient({
       <Link
         href={`/trip/${trip.id}`}
         prefetch={true}
-        className="block bg-white rounded-xl shadow-sm border border-gray-300 p-6 hover:shadow-md transition-shadow"
+        className="block bg-white rounded-xl shadow-sm border border-gray-300 p-6 hover:shadow-md transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:border-transparent"
       >
         <div className="flex items-start justify-between mb-3">
           <span className="text-3xl">{getTripEmoji(trip.tripType)}</span>
@@ -157,10 +157,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 flex gap-1 transition-opacity">
+      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-1 transition-opacity">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -168,7 +168,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
@@ -182,7 +182,7 @@ export default function DashboardClient({
       <Link
         href={`/trip/${trip.id}`}
         prefetch={true}
-        className="block bg-white rounded-lg border border-gray-300 p-4 hover:border-gray-300 transition-colors"
+        className="block bg-white rounded-lg border border-gray-300 p-4 hover:border-gray-300 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:border-transparent"
       >
         <div className="flex items-center gap-3">
           <span className="text-2xl">{getTripEmoji(trip.tripType)}</span>
@@ -200,10 +200,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
+      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -211,7 +211,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}


### PR DESCRIPTION
💡 What: Added visual focus indicators (`focus-visible:ring-2`) to main trip card links and ensured that hover-only secondary action buttons (Edit/Delete) become visible during keyboard navigation using `focus-within:opacity-100`.
🎯 Why: Keyboard-only users were unable to see when they were focused on a trip card link (due to lack of focus ring) and could not discover or trigger the Edit/Delete actions because they remained hidden (`opacity-0`) without mouse hover.
📸 Before/After: See Playwright screenshot/video verification.
♿ Accessibility: Improves WCAG compliance for focus visibility (2.4.7) by providing clear visual indicators for interactive elements.

---
*PR created automatically by Jules for task [16259075352693435279](https://jules.google.com/task/16259075352693435279) started by @mvng*