### PR TITLE
🔍 Scout: [SEO improvement] Add dynamic sitemap and robots generation

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-05-10 - [Next.js App Router robots.txt and sitemap.xml generation]
+**Learning:** In Next.js App Router, instead of relying on static files in the `public` directory which limit flexibility, you can dynamically generate `robots.txt` and `sitemap.xml` by exporting standard functions (`MetadataRoute.Robots` and `MetadataRoute.Sitemap`) from `app/robots.ts` and `app/sitemap.ts`. This natively supports using environment variables for the base URL and programmatically isolating private vs public routes.
+**Action:** When auditing or implementing crawl scope optimization, replace static XML/TXT files with these dynamic TypeScript files to automatically protect authenticated routes and ensure the sitemap reflects the true host environment.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// The robots.txt file guides search engine crawlers on which parts of the site they should and should not crawl.
+// We are explicitly disallowing private authenticated routes (/dashboard, /settings, /inventory, /luggage) and
+// user-specific shared trip pages (/trip/). This prevents indexation of sensitive or non-public content and
+// optimizes crawl efficiency for the public routes (like '/' and '/login') by preserving crawl budget.
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: ['/dashboard/', '/settings/', '/inventory/', '/luggage/', '/trip/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Generating a sitemap.xml explicitly defines the public URL structure of the application.
+// We only include the landing page ('/') and the login page ('/login') because all other
+// pages (dashboard, settings, inventory, luggage, trip details) are private or user-specific.
+// This prevents search crawlers from wasting crawl budget on authenticated routes that they
+// cannot access and ensures only indexable public content is discovered.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** 
Added dynamic Next.js `sitemap.ts` and `robots.ts` files to root level.

🎯 **Why:** 
The application was missing proper crawling instructions, which could lead to search engines wasting crawl budget on private paths or failing to map the main entry points correctly. This defines the crawl scope.

📊 **Impact:** 
Optimizes crawl efficiency by explicitly avoiding authenticated user sections (`/dashboard`, `/settings`, `/inventory`, `/luggage`, `/trip/`) and guides crawlers to the indexable public paths (`/` and `/login`), ultimately improving SEO discoverability.

🔬 **Verification:** 
Visit `/robots.txt` or `/sitemap.xml` directly in the browser to view the dynamic metadata output.

🔗 **References:** 
- [Next.js robots.txt Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)
- [Next.js sitemap.xml Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [12044366804760515005](https://jules.google.com/task/12044366804760515005) started by @mvng*