### PR TITLE
🎨 Palette: [UX improvement] Improve keyboard accessibility for hover states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve keyboard accessibility for hover-revealed tooltips
+**Learning:** Found that custom tooltips and elements hidden via `opacity-0` and revealed via `group-hover:opacity-100` are completely invisible to keyboard-only users who tab through the interface.
+**Action:** Always pair `group-hover:opacity-100` with `group-focus-within:opacity-100` (or `focus-within:opacity-100`) on the parent container, and ensure interactive trigger elements (like paragraphs showing tooltips) have `tabIndex={0}` and `focus-visible` styles so they can receive keyboard focus and reveal the tooltip.

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -119,7 +119,7 @@ export default function DashboardClient({
       <Link
         href={`/trip/${trip.id}`}
         prefetch={true}
-        className="block bg-white rounded-xl shadow-sm border border-gray-300 p-6 hover:shadow-md transition-shadow"
+        className="block bg-white rounded-xl shadow-sm border border-gray-300 p-6 hover:shadow-md transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
       >
         <div className="flex items-start justify-between mb-3">
           <span className="text-3xl">{getTripEmoji(trip.tripType)}</span>
@@ -157,10 +157,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 flex gap-1 transition-opacity">
+      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-1 transition-opacity">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -168,7 +168,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
@@ -182,7 +182,7 @@ export default function DashboardClient({
       <Link
         href={`/trip/${trip.id}`}
         prefetch={true}
-        className="block bg-white rounded-lg border border-gray-300 p-4 hover:border-gray-300 transition-colors"
+        className="block bg-white rounded-lg border border-gray-300 p-4 hover:border-gray-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
       >
         <div className="flex items-center gap-3">
           <span className="text-2xl">{getTripEmoji(trip.tripType)}</span>
@@ -200,10 +200,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
+      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -211,7 +211,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}

--- a/app/trip/[id]/TripPageClient.tsx
+++ b/app/trip/[id]/TripPageClient.tsx
@@ -209,12 +209,12 @@ export default function TripPageClient({ initialTrip, user, isOwner, initialTrip
                 )}
                 {trip.startDate && (
                   <div className="relative inline-block group">
-                    <p className="text-sm text-gray-500 cursor-help mt-1">
+                    <p tabIndex={0} className="text-sm text-gray-500 cursor-help mt-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:rounded-sm">
                       {formatDate(trip.startDate)}
                       {trip.endDate && ` – ${formatDate(trip.endDate)}`}
                     </p>
                     {timezoneTooltip && (
-                      <div className="absolute left-0 top-full mt-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+                      <div className="absolute left-0 top-full mt-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none z-10">
                         <div className="bg-gray-900 text-white text-xs px-2 py-1 rounded whitespace-nowrap">{timezoneTooltip}</div>
                       </div>
                     )}
@@ -306,7 +306,7 @@ export default function TripPageClient({ initialTrip, user, isOwner, initialTrip
                 <PlanningBoardView trip={displayTrip} onUnsyncedItemsChange={setUnsyncedItems} />
                 
                 {unsyncedItems.length > 0 && (
-                  <div className="relative group flex items-center justify-center lg:justify-start">
+                  <div className="relative group flex items-center justify-center lg:justify-start focus-within:opacity-100">
                     <button
                       disabled={isSyncing || isPending}
                       onClick={async () => {
@@ -330,7 +330,7 @@ export default function TripPageClient({ initialTrip, user, isOwner, initialTrip
                         <><RefreshCw className="w-4 h-4" /> Sync {unsyncedItems.length} items to Packing List</>
                       )}
                     </button>
-                    <div className="absolute lg:left-0 lg:-translate-x-0 left-1/2 -translate-x-1/2 top-full mt-2 w-max max-w-xs bg-gray-900 text-white text-xs rounded shadow-lg p-3 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
+                    <div className="absolute lg:left-0 lg:-translate-x-0 left-1/2 -translate-x-1/2 top-full mt-2 w-max max-w-xs bg-gray-900 text-white text-xs rounded shadow-lg p-3 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none z-50">
                       <p className="font-semibold mb-2 border-b border-gray-700 pb-1 text-left">Adding {unsyncedItems.length} item{unsyncedItems.length !== 1 && 's'}:</p>
                       <ul className="list-disc pl-4 text-left space-y-1 text-gray-200">
                         {unsyncedItems.slice(0, 5).map(item => (

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,16 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
-              title={member.name}
+              aria-label={member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,8 +84,8 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
-            title="Add member"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            aria-label="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -110,15 +110,15 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
-            title="Confirm"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            aria-label="Confirm"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
-            title="Cancel"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            aria-label="Cancel"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
💡 What: The UX enhancement added
Added robust keyboard accessibility to hover-revealed elements (action buttons, tooltips) across the Dashboard, Trip Page, and Trip Members sections. Replaced native `title` tooltips with `aria-label`s on icon-only buttons to prevent double-announcements.

🎯 Why: The user problem it solves
Previously, important action buttons (edit/delete trip) and tooltips (member names, timezone differences) were strictly tied to mouse pointer `hover` states (`opacity-0 group-hover:opacity-100`). Keyboard-only users tabbing through the interface could not see what they were focused on or read the tooltips. This makes the interface much more inclusive and accessible.

📸 Before/After: Screenshots if visual change
Visually unchanged for mouse users. Keyboard users now see a clean blue focus ring (`focus-visible:ring-blue-500`) around interactive elements, and hidden elements now smoothly fade in upon receiving focus (`group-focus-within:opacity-100`).

♿ Accessibility: Any a11y improvements made
- Replaced `title` with `aria-label` on icon buttons.
- Added `focus-within` and `group-focus-within` logic to all custom tooltips and hidden action groups.
- Ensured non-button triggers (like the timezone text) have `tabIndex={0}` to be focusable.
- Added specific `focus-visible:ring-2` to links and buttons for clear focus indicators.

---
*PR created automatically by Jules for task [18395742601459200207](https://jules.google.com/task/18395742601459200207) started by @mvng*