### PR TITLE
🎨 Palette: [UX improvement] Enhance CalendarSyncDropdown accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Enhance CalendarSyncDropdown accessibility
+**Learning:** Discovered that custom dropdown menus created with React state often lack keyboard accessibility and standard ARIA properties, rendering them difficult or impossible to use for keyboard navigators and screen readers. Specifically, the `CalendarSyncDropdown` was missing an `Escape` key close handler, `aria-expanded`/`aria-haspopup` attributes, `role="menu"` semantics, and focus styles on both the trigger and menu items.
+**Action:** When creating custom interactive popovers or dropdowns, always implement an `Escape` key handler, provide `focus-visible` styling (along with explicit `focus:` classes for children items like links to simulate hover states on tab), and map out the component with proper `role="menu"`, `aria-haspopup="menu"`, and `aria-expanded` attributes.

--- a/components/CalendarSyncDropdown.tsx
+++ b/components/CalendarSyncDropdown.tsx
@@ -16,9 +16,18 @@ export default function CalendarSyncDropdown({ tripId }: CalendarSyncDropdownPro
         setShowCalendarMenu(false)
       }
     }
+
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setShowCalendarMenu(false)
+      }
+    }
+
     document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleEscape)
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleEscape)
     }
   }, [])
 
@@ -26,22 +35,27 @@ export default function CalendarSyncDropdown({ tripId }: CalendarSyncDropdownPro
     <div className="relative" ref={calendarMenuRef}>
       <button
         onClick={() => setShowCalendarMenu(!showCalendarMenu)}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all"
-        title="Calendar Sync"
+        className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        aria-expanded={showCalendarMenu}
+        aria-haspopup="menu"
       >
         <span>📅</span>
         <span className="hidden sm:inline">Add to Calendar</span>
       </button>
 
       {showCalendarMenu && (
-        <div className="absolute right-0 mt-2 w-64 bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden z-20">
+        <div
+          className="absolute right-0 mt-2 w-64 bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden z-20"
+          role="menu"
+        >
           <div className="p-3 bg-gray-50 border-b border-gray-100">
             <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Auto-updating</h3>
           </div>
           <a
             href={typeof window !== 'undefined' ? `webcal://${window.location.host}/api/calendar/${tripId}` : `/api/calendar/${tripId}`}
-            className="block px-4 py-3 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700 border-b border-gray-100"
+            className="block px-4 py-3 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700 focus:bg-blue-50 focus:text-blue-700 focus:outline-none transition-colors border-b border-gray-100"
             onClick={() => setShowCalendarMenu(false)}
+            role="menuitem"
           >
             <div className="font-medium mb-0.5">Subscribe to Calendar (webcal)</div>
             <div className="text-xs text-gray-500">Apple Calendar, Outlook. Syncs packing progress!</div>
@@ -52,8 +66,9 @@ export default function CalendarSyncDropdown({ tripId }: CalendarSyncDropdownPro
           </div>
           <a
             href={`/api/calendar/${tripId}`}
-            className="block px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700"
+            className="block px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700 focus:bg-blue-50 focus:text-blue-700 focus:outline-none transition-colors"
             onClick={() => setShowCalendarMenu(false)}
+            role="menuitem"
           >
             Download .ics file
           </a>


### PR DESCRIPTION
💡 What: Added ARIA attributes (`aria-expanded`, `aria-haspopup`, `role="menu"`, `role="menuitem"`), an Escape key listener, and focus states to the CalendarSyncDropdown component.
🎯 Why: Custom dropdown menus built with standard `div`s and React state are inaccessible to keyboard navigators and screen readers unless they implement standard ARIA menu patterns and explicit keyboard listeners (like closing on Escape and visible focus rings).
📸 Before/After: Verified via Playwright screenshot; the trigger button and menu items now display focus rings when tabbed to, and the dropdown is semantically recognized as a menu.
♿ Accessibility: Ensures full keyboard accessibility and screen reader support for the calendar sync feature.

---
*PR created automatically by Jules for task [6319117612350270040](https://jules.google.com/task/6319117612350270040) started by @mvng*