### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in PackingListSection

### DIFF
--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -748,6 +748,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
             <button
               onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
               title="Add/Edit Note"
+              aria-label="Add or edit note"
               className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
             ><MessageSquare className="w-3.5 h-3.5" /></button>
             <button
@@ -1263,14 +1264,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                   <button
                                     onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
                                     title="Add/Edit Note"
+                                    aria-label="Add or edit note"
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
                                   ><MessageSquare className="w-3.5 h-3.5" /></button>
                                   <button
                                     onClick={() => handleTogglePackLast(item.id, category.id, list.id, item.packLast)}
                                     title="Add to departure checklist"
+                                    aria-label={item.packLast ? 'Remove from pack last' : 'Mark as pack last'}
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center"
                                   ><Sunrise className="w-3.5 h-3.5" /></button>
-                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
+                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} aria-label={`Remove ${item.name} from packing list`} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
                                 </div>
                               )}
                             </li>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to the "Add/Edit Note" and "Delete" icon-only action buttons within the `PackingListSection` component.
🎯 Why: To improve accessibility for screen reader users by providing descriptive labels for interactive elements that only have visual icons.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Ensures that keyboard and screen-reader users understand the context and purpose of the action buttons attached to each packing list item.

---
*PR created automatically by Jules for task [11176621346903074693](https://jules.google.com/task/11176621346903074693) started by @mvng*