### PR TITLE
🔍 Scout: [SEO improvement] Add sitemap and robots.txt

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-03-20 - [Sitemaps and Robots Configuration]
+**Learning:** In Next.js App Router, instead of relying on static files in `public/`, natively generate `robots.txt` and `sitemap.xml` dynamically by creating `app/robots.ts` and `app/sitemap.ts` files that export functions returning `MetadataRoute.Robots` and `MetadataRoute.Sitemap` respectively.
+**Action:** When implementing site crawlability rules, utilize the `MetadataRoute` functionality to programmatically generate sitemaps and robots config rather than static raw files.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = 'https://packwise-indol.vercel.app'
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage', '/trip/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,19 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://packwise-indol.vercel.app'
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** Added `app/robots.ts` and `app/sitemap.ts` files that export Next.js `MetadataRoute` configurations to dynamically generate `robots.txt` and `sitemap.xml`.
🎯 **Why:** To improve site discoverability for search engines. It ensures public landing and login pages are crawled efficiently while preventing private/authenticated routes (`/dashboard`, `/settings`, `/inventory`, `/luggage`, `/trip/`) from being indexed.
📊 **Impact:** Improves overall crawl efficiency, directs search engines to core pages, and prevents index bloat with un-crawlable private links.
🔬 **Verification:** Verify the output by visiting `/robots.txt` and `/sitemap.xml` in the browser or using Google Search Console URL Inspection Tool.
🔗 **References:** [Next.js robots.txt Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots) and [Next.js sitemap.xml Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap).

---
*PR created automatically by Jules for task [17076283976495063374](https://jules.google.com/task/17076283976495063374) started by @mvng*