### PR TITLE
🔍 Scout: Add dynamic robots.txt and sitemap.xml for SEO

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-05-13 - [Next.js App Router robots.txt and sitemap.xml]
+**Learning:** In Next.js App Router, natively generate `robots.txt` and `sitemap.xml` dynamically by creating `app/robots.ts` and `app/sitemap.ts` files that export functions returning `MetadataRoute.Robots` and `MetadataRoute.Sitemap` respectively, rather than relying on static files in the `public` directory.
+**Action:** Always prefer dynamic metadata generation for site-wide SEO files in the Next.js `app` directory to allow environment variable usage and dynamic routing logic.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  // Use the same base URL as configured in layout.tsx or an environment variable.
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // 🔍 SEO rationale: Explicitly block crawlers from indexing private, authenticated
+  // routes and user-specific shared trip pages to prevent thin/duplicate content
+  // and protect privacy. Allow crawling on all other public routes.
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/inventory/',
+        '/luggage/',
+        '/trip/',
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // 🔍 SEO rationale: Explicitly listing public routes like / and /login helps search
+  // engines discover these entry points quickly and assign appropriate crawl priority.
+  // Private routes are intentionally excluded from the sitemap.
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** 
Implemented Next.js dynamic routing for SEO by creating `app/robots.ts` and `app/sitemap.ts` to natively generate `robots.txt` and `sitemap.xml` respectively.

🎯 **Why:** 
To enhance search engine visibility and crawl efficiency. The `robots.txt` explicitly allows crawling of public pages while blocking indexation of private, authenticated routes (`/dashboard`, `/settings`, `/inventory`, `/luggage`) and user-specific shared paths (`/trip/`) to protect privacy and prevent duplicate/thin content penalties. The `sitemap.xml` prioritizes the discovery of the primary public entry points (`/` and `/login`).

📊 **Impact:** 
Improves site crawlability, ensures private user data stays out of search indexes, and helps search engines prioritize the main landing and authentication pages.

🔬 **Verification:** 
- `pnpm lint` and `pnpm test` executed successfully.
- Verified output matches Next.js `MetadataRoute.Robots` and `MetadataRoute.Sitemap` native types.
- The `robots.ts` file correctly formats trailing slashes for the generated `sitemap.xml` location.

🔗 **References:** 
- Next.js Metadata API Documentation: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots
- Google Search Central robots.txt Specifications: https://developers.google.com/search/docs/crawling-indexing/robots/intro

---
*PR created automatically by Jules for task [12238574209111387600](https://jules.google.com/task/12238574209111387600) started by @mvng*