### PR TITLE
🎨 Palette: Make Calendar Sync dropdown keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+
+## 2024-05-13 - Focus Styles on Dropdowns using focus-visible
+**Learning:** For custom dropdown components (like `CalendarSyncDropdown`), standard `focus:` classes might not provide clear enough visual feedback for keyboard users or could display when clicked with a mouse.
+**Action:** Always prefer `focus-visible:` utilities over `focus:` on interactive elements. Ensure ARIA roles (e.g. `role="menu"`, `role="menuitem"`) and an Escape key listener are included when making custom interactive elements accessible.

--- a/components/CalendarSyncDropdown.tsx
+++ b/components/CalendarSyncDropdown.tsx
@@ -16,9 +16,18 @@ export default function CalendarSyncDropdown({ tripId }: CalendarSyncDropdownPro
         setShowCalendarMenu(false)
       }
     }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setShowCalendarMenu(false)
+      }
+    }
+
     document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleKeyDown)
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
     }
   }, [])
 
@@ -26,22 +35,28 @@ export default function CalendarSyncDropdown({ tripId }: CalendarSyncDropdownPro
     <div className="relative" ref={calendarMenuRef}>
       <button
         onClick={() => setShowCalendarMenu(!showCalendarMenu)}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all"
+        className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         title="Calendar Sync"
+        aria-expanded={showCalendarMenu}
+        aria-haspopup="menu"
       >
         <span>📅</span>
         <span className="hidden sm:inline">Add to Calendar</span>
       </button>
 
       {showCalendarMenu && (
-        <div className="absolute right-0 mt-2 w-64 bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden z-20">
+        <div
+          className="absolute right-0 mt-2 w-64 bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden z-20"
+          role="menu"
+        >
           <div className="p-3 bg-gray-50 border-b border-gray-100">
             <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Auto-updating</h3>
           </div>
           <a
             href={typeof window !== 'undefined' ? `webcal://${window.location.host}/api/calendar/${tripId}` : `/api/calendar/${tripId}`}
-            className="block px-4 py-3 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700 border-b border-gray-100"
+            className="block px-4 py-3 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700 border-b border-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
             onClick={() => setShowCalendarMenu(false)}
+            role="menuitem"
           >
             <div className="font-medium mb-0.5">Subscribe to Calendar (webcal)</div>
             <div className="text-xs text-gray-500">Apple Calendar, Outlook. Syncs packing progress!</div>
@@ -52,8 +67,9 @@ export default function CalendarSyncDropdown({ tripId }: CalendarSyncDropdownPro
           </div>
           <a
             href={`/api/calendar/${tripId}`}
-            className="block px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700"
+            className="block px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
             onClick={() => setShowCalendarMenu(false)}
+            role="menuitem"
           >
             Download .ics file
           </a>


### PR DESCRIPTION
💡 What: Added an `Escape` key event listener to close the Calendar Sync dropdown menu, added appropriate semantic ARIA roles (`role="menu"`, `role="menuitem"`, `aria-expanded`, `aria-haspopup`), and enhanced the keyboard focus visibility using Tailwind's `focus-visible` utility classes for the toggle button and menu links.

🎯 Why: Custom dropdown menus often lack native keyboard support, which can trap keyboard users or make it difficult to navigate away without a mouse. These changes make the component behave closer to a native `<select>` or `<details>` element in terms of keyboard and screen reader accessibility.

♿ Accessibility:
- Added `Escape` key support to close the menu.
- Added `aria-expanded` and `aria-haspopup="menu"` to the toggle button.
- Added `role="menu"` to the dropdown container.
- Added `role="menuitem"` to the links within the menu.
- Added clear, high-contrast visual focus rings using `focus-visible:ring-2 focus-visible:ring-blue-500` (and `focus-visible:ring-inset` for internal links) that only appear when navigating with a keyboard.

---
*PR created automatically by Jules for task [6694820351447451279](https://jules.google.com/task/6694820351447451279) started by @mvng*