### PR TITLE
🎨 Palette: Improve keyboard accessibility on Dashboard trip cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+
+## 2026-05-14 - Dashboard Keyboard Accessibility for Hover Actions
+**Learning:** In this project's UI patterns, hover-revealed action button containers (like the Edit/Delete absolute positioning blocks on Dashboard trip cards using `opacity-0 group-hover:opacity-100`) completely bypass keyboard accessibility without explicit focus-within styles. `group-focus-within:opacity-100` must be added to the container, and `focus-visible:` utilities must be added directly to the interactive children to support `Tab` navigation.
+**Action:** When implementing or reviewing any `group-hover` revealed interactive elements across the application (like in PlanningBoardView or PackingListSection), always mandate a corresponding `group-focus-within` and explicit child `focus-visible` ring.

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -157,10 +157,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 flex gap-1 transition-opacity">
+      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 flex gap-1 transition-opacity">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -168,7 +168,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
@@ -200,10 +200,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
+      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -211,7 +211,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}


### PR DESCRIPTION
### 💡 What
Added keyboard accessibility support for the "Edit" and "Delete" actions on the trip cards in the dashboard. These buttons were previously only visible on hover. They are now revealed when a keyboard user tabs into them, and feature a clear visual focus ring (blue for edit, red for delete).

### 🎯 Why
To ensure the application remains fully accessible to users relying on keyboard navigation (e.g., screen reader users, power users, or users with motor disabilities). Before this change, tabbing through the interface would focus on invisible elements, making the trip management functions undiscoverable.

### 📸 Before/After
*(Frontend verification completed via Playwright. Screenshot attached in verification phase demonstrating the blue focus ring on the 'Edit' button while navigating via keyboard).*

### ♿ Accessibility
- Implemented `group-focus-within` to reveal hidden interactive containers.
- Added explicit `focus-visible:outline-none focus-visible:ring-2` to interactive elements to ensure focus states are clearly delineated without breaking the mouse-hover aesthetics.

---
*PR created automatically by Jules for task [15566891510539466025](https://jules.google.com/task/15566891510539466025) started by @mvng*