### PR TITLE
🔍 Scout: Add dynamic robots.txt and sitemap.xml for crawler control

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+// SEO Rationale: A robots.txt file directs search engine crawlers on which pages they can or cannot index.
+// By explicitly disallowing private authenticated routes (/dashboard, /settings, etc.), we prevent search engines
+// from wasting crawl budget on inaccessible pages, and focus their attention on our public landing pages.
+export default function robots(): MetadataRoute.Robots {
+  // Ensure trailing slash is safely trimmed from the base URL if it exists
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/inventory/',
+        '/luggage/',
+        '/trip/',
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+// SEO Rationale: A sitemap.xml explicitly lists the URLs that are available for crawling, along with metadata like
+// priority and last modification dates. This helps search engines discover our public pages faster and more reliably
+// than relying solely on link traversal.
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Ensure trailing slash is safely trimmed from the base URL if it exists
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What**: Implemented dynamic `robots.ts` and `sitemap.ts` files using Next.js `MetadataRoute` to programmatically generate `robots.txt` and `sitemap.xml`.
🎯 **Why**: To explicitly disallow crawling on private authenticated routes (`/dashboard`, `/settings`, `/inventory`, `/luggage`, `/trip`) preventing crawl budget waste, and to provide search engines a structured map of our public pages (`/` and `/login`) to improve discoverability.
📊 **Impact**: Increases the visibility of public landing pages while strictly preventing indexation of private user data or dynamic app paths.
🔬 **Verification**: Run `pnpm run build` and inspect the Next.js `.next` folder or build output to ensure `robots.txt` and `sitemap.xml` are correctly structured, and verified locally by Playwright testing.
🔗 **References**: [Next.js Metadata Route Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

---
*PR created automatically by Jules for task [3223570027214010760](https://jules.google.com/task/3223570027214010760) started by @mvng*