### PR TITLE
🔍 Scout: [SEO improvement] Add dynamic robots.txt and sitemap.xml

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-05-15 - [Next.js App Router Dynamic SEO Files]
+**Learning:** In Next.js App Router, instead of placing static `robots.txt` and `sitemap.xml` files in the `public` directory, they can and should be dynamically generated using the Next.js Metadata API by creating `app/robots.ts` and `app/sitemap.ts` files. This allows the files to automatically adjust to dynamic environment variables like `NEXT_PUBLIC_APP_URL` and explicitly control crawler access across different environments (e.g., development vs. production).
+**Action:** When implementing or fixing core SEO configuration files in a Next.js App Router project, always favor native dynamic generation (`robots.ts`, `sitemap.ts`) over static files to ensure they remain in sync with the environment and build processes.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,19 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Explicitly generating a robots.txt prevents search engines from crawling
+// authenticated or private user routes (like /dashboard or /trip/)
+// while allowing them to index public landing pages.
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login'],
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage', '/trip/', '/api/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Providing a dynamic sitemap.xml ensures search engines can efficiently
+// discover and index the primary public entry points of the application,
+// prioritizing the main landing page.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** 
Implemented `app/robots.ts` and `app/sitemap.ts` using the Next.js Metadata API to dynamically generate `robots.txt` and `sitemap.xml`.

🎯 **Why:** 
The application was previously missing explicit search crawler instructions. Providing a dynamic `sitemap.xml` ensures search engines can efficiently discover and index the primary public entry points (`/` and `/login`). Explicitly generating a `robots.txt` prevents search engines from unnecessarily crawling authenticated or private user routes (like `/dashboard`, `/settings`, or `/trip/`), focusing crawler budget on valuable landing pages.

📊 **Impact:** 
Improves indexability for public pages and prevents potential SEO penalties associated with crawling private/unauthenticated states or error views in restricted areas.

🔬 **Verification:** 
- `pnpm lint` passing with no issues.
- All relevant playwright unit tests passing.
- Verified dynamic `/robots.txt` and `/sitemap.xml` outputs via local dev server using `curl`.
- Confirmed the generated XML output is correctly formatted according to Google standards.

🔗 **References:** 
- [Next.js Documentation: robots.txt](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)
- [Next.js Documentation: sitemap.xml](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [4683425093046698038](https://jules.google.com/task/4683425093046698038) started by @mvng*