### PR TITLE
🎨 Palette: [Trip members accessibility focus states]

### DIFF
--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -59,9 +59,10 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
               className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
-                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
+                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={`Remove ${member.name}`}
             >
               <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
               {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
@@ -84,8 +85,9 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Add member"
+            aria-label="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -110,15 +112,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Confirm"
+            aria-label="Confirm add member"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
             title="Cancel"
+            aria-label="Cancel add member"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
### 💡 What
Added semantic `aria-label` properties and explicit `focus-visible:ring-2` Tailwind utility classes to the icon-only buttons inside `components/TripMembersSection.tsx` (the Remove, Add, Confirm, and Cancel buttons). 

### 🎯 Why
Previously, the interactive buttons inside the `TripMembersSection` lacked proper accessible labels and visible focus indicators. The visual feedback relied purely on mouse `hover:` pseudo-classes. This made it impossible for screen reader users to understand what the buttons did, and it made it very difficult for keyboard-only users to navigate the trip member list as tab-focus was functionally invisible.

### 📸 Before/After
- **Before:** Buttons used `title` but lacked `aria-label`. Tabbed focus rings were invisible.
- **After:** Sighted mouse users see standard hover tooltips. Screen reader users hear context-aware labels (e.g. "Remove Grandma"). Keyboard-only users see distinct outline rings when navigating via the `Tab` key.

### ♿ Accessibility
- Added context-aware `aria-label` attributes to dynamic mapped lists (e.g., ``aria-label={`Remove ${member.name}`}``).
- Bound focus styling to `focus-visible` to enhance keyboard accessibility without ruining mouse click UX with sticky focus rings.

---
*PR created automatically by Jules for task [1827218435629150889](https://jules.google.com/task/1827218435629150889) started by @mvng*