### PR TITLE
⚡ Bolt: [performance improvement] Batch task updates in cron reminder job

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+## 2025-05-16 - Batch updates for cron jobs
+**Learning:** In `app/api/cron/send-reminders/route.ts`, an N+1 query problem was present where `await prisma.tripTask.update()` was called inside a loop over tasks. This is a common performance bottleneck in serverless environments.
+**Action:** When iterating over database records to update a common field (like a timestamp), collect the IDs into an array and execute a single `updateMany` batch operation outside the loop.

--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -33,6 +33,8 @@ export async function GET(request: NextRequest) {
 
     console.log(`Processing ${tasks.length} reminders...`)
 
+    const taskIdsToUpdate: string[] = []
+
     for (const task of tasks) {
       const { reminderTypes } = task
 
@@ -75,9 +77,15 @@ export async function GET(request: NextRequest) {
         console.log(`[CALENDAR] Calendar invite generated for task: ${task.title}`)
       }
 
-      // Mark as sent
-      await prisma.tripTask.update({
-        where: { id: task.id },
+      taskIdsToUpdate.push(task.id)
+    }
+
+    if (taskIdsToUpdate.length > 0) {
+      // ⚡ Bolt Performance Optimization
+      // Why: Replaced N+1 individual update queries with a single updateMany batch operation.
+      // Impact: Reduces database round-trips from O(N) to O(1), improving cron execution time.
+      await prisma.tripTask.updateMany({
+        where: { id: { in: taskIdsToUpdate } },
         data: { reminderSentAt: now }
       })
     }


### PR DESCRIPTION
### 💡 What
Replaced individual `prisma.tripTask.update` calls inside the task processing loop with a single `prisma.tripTask.updateMany` call outside the loop in `app/api/cron/send-reminders/route.ts`.

### 🎯 Why
To eliminate an N+1 query performance bottleneck. Previously, if the cron job processed 100 reminders, it would execute 100 individual database `UPDATE` statements. By collecting the task IDs, we execute exactly 1 `UPDATE` statement regardless of the number of reminders, drastically reducing network overhead and database load.

### 📊 Impact
Reduces database round-trips from O(N) to O(1) during cron execution, resulting in faster and more resilient serverless function execution.

### 🔬 Measurement
Run `pnpm test` to verify no functionality is broken (the changes are entirely backend/API focused). Code inspection of `app/api/cron/send-reminders/route.ts` confirms the loop now only pushes strings to an array, and the `updateMany` query occurs sequentially at the end.

---
*PR created automatically by Jules for task [7444799814051677398](https://jules.google.com/task/7444799814051677398) started by @mvng*