### PR TITLE
🎨 Palette: Add accessible focus states to trip actions

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -157,19 +157,19 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 flex gap-1 transition-opacity">
+      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-1 transition-opacity">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center"
-          aria-label="Edit trip"
+          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 flex items-center justify-center"
+          aria-label={`Edit trip to ${trip.destination || 'unknown destination'}`}
         >
           <Edit2 className="w-4 h-4" />
         </button>
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center"
-          aria-label="Delete trip"
+          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 flex items-center justify-center"
+          aria-label={`Delete trip to ${trip.destination || 'unknown destination'}`}
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
         </button>
@@ -200,19 +200,19 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
+      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center"
-          aria-label="Edit trip"
+          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 flex items-center justify-center"
+          aria-label={`Edit trip to ${trip.destination || 'unknown destination'}`}
         >
           <Edit2 className="w-4 h-4" />
         </button>
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center"
-          aria-label="Delete trip"
+          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 flex items-center justify-center"
+          aria-label={`Delete trip to ${trip.destination || 'unknown destination'}`}
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
         </button>


### PR DESCRIPTION
💡 What: Added `focus-within:opacity-100` to the trip card action containers, added `focus-visible` rings to the "Edit" and "Delete" buttons, and improved `aria-label`s to interpolate the trip destination.
🎯 Why: Previously, keyboard-only and screen reader users navigating the dashboard could not easily access or identify the trip card action buttons because they were strictly hidden behind `group-hover:opacity-100` and used generic "Edit trip" labels. 
📸 Before/After: Action buttons now remain visible during tab-navigation with clear blue/red focus rings.
♿ Accessibility: Ensures keyboard discoverability via `focus-within`, visible keyboard tracking via `focus-visible`, and semantic context for screen readers via updated `aria-label`s.

---
*PR created automatically by Jules for task [15909254263735005919](https://jules.google.com/task/15909254263735005919) started by @mvng*