### PR TITLE
🎨 Palette: Improve TripMembersSection accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve TripMembersSection accessibility
+**Learning:** Found that tooltip containers implementing hover logic using `group-hover` lacked keyboard accessibility. Tooltips require `group-focus-within:opacity-100` alongside `group-hover` so they appear during keyboard navigation as well. Also found icon-only action buttons relying solely on the native `title` attribute for tooltip/context lacking explicit `aria-label`s.
+**Action:** Always ensure hover-revealed tooltips include `group-focus-within:opacity-100` alongside `group-hover`. For icon-only buttons, maintain `title` but add an explicit `aria-label` for screen reader fallback. Also, ensure buttons styled with raw colors (`bg-red-100`) include appropriate `focus-visible` styles with a high contrast ring.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -59,15 +59,15 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
               className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
-                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
+                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1 focus-visible:bg-red-100 focus-visible:text-red-600' : 'cursor-default'
               }`}
-              title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
               <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
               {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,8 +84,9 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:border-transparent"
             title="Add member"
+            aria-label="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -100,6 +101,7 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
             value={newName}
             onChange={e => setNewName(e.target.value)}
             placeholder="Name (e.g. Peter, Grandma)"
+            aria-label="New member name"
             className="text-xs px-2.5 py-1.5 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white w-48"
             onKeyDown={e => {
               if (e.key === 'Enter') handleAdd()
@@ -110,15 +112,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
             title="Confirm"
+            aria-label="Confirm"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
             title="Cancel"
+            aria-label="Cancel"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
### 💡 What
- Added explicit `aria-label`s to the Add, Remove, Confirm, and Cancel icon-only buttons in `TripMembersSection`.
- Improved tooltip accessibility by adding `group-focus-within:opacity-100` so tooltips appear during keyboard focus, not just on mouse hover.
- Added explicit `focus-visible:ring-2` utility classes to all interactive buttons and inputs for clear keyboard navigation indicators.

### 🎯 Why
- Mouse users benefit from `title` tooltips or visual layout context, but screen reader and keyboard-only users could not discern the purpose of icon-only action buttons.
- Tooltips revealed only on `hover` were entirely invisible during keyboard navigation.
- Several raw styled buttons lacked standard focus rings, breaking the visual tab order.

### 📸 Before/After
- **Before:** Buttons lacked `aria-label`s, custom tooltips used only `group-hover:opacity-100`, and some buttons (like the Remove member `bg-red-100` pill) had no clear focus state.
- **After:** Screen readers announce exact button functions (e.g. "Remove Peter"), keyboard focus reveals tooltip contexts, and all elements properly glow with blue/red outlines when tab-focused.

### ♿ Accessibility
- Enhanced screen reader context mapping for dynamically generated list rows.
- Restored visual discovery parity for keyboard-only users navigating the component.

---
*PR created automatically by Jules for task [12372675836834852357](https://jules.google.com/task/12372675836834852357) started by @mvng*