### PR TITLE
🔍 Scout: Add native sitemap.xml and robots.txt generation

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SEO improvement: Added robots.txt configuration to explicitly control crawl scope
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login', '/claim/'],
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/inventory/',
+        '/luggage/',
+        '/trip/',
+        '/api/'
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,22 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  // SEO improvement: Added sitemap.xml generation for crawlability
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:**
Implemented native Next.js metadata generation for `sitemap.xml` and `robots.txt` using the App Router's `app/sitemap.ts` and `app/robots.ts` file conventions.

🎯 **Why:**
The application was previously missing explicit instructions for search engine crawlers. Adding these files ensures that public pages (`/`, `/login`, `/claim/`) are properly indexed and crawlable, while explicitly disallowing private user routes (`/dashboard/`, `/settings/`, `/api/`, etc.) from being crawled, preventing PII leaks in search results and optimizing the crawl budget.

📊 **Impact:**
Improves search visibility for public landing pages and ensures private authenticated routes are kept out of search engine indices.

🔬 **Verification:**
Verified the contents correctly generated using `cat app/sitemap.ts app/robots.ts`. The implementation trims trailing slashes from the base URL and dynamically reads `NEXT_PUBLIC_APP_URL` safely. Local linting and test suites passed successfully.

🔗 **References:**
- [Next.js Docs: Metadata Files (robots.txt)](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)
- [Next.js Docs: Metadata Files (sitemap.xml)](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [14267863654085191596](https://jules.google.com/task/14267863654085191596) started by @mvng*