### PR TITLE
🔍 Scout: Add dynamic sitemap and robots.txt

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-05-19 - [Dynamic Sitemap and Robots in Next.js App Router]
+**Learning:** Next.js App Router natively supports generating `robots.txt` and `sitemap.xml` dynamically by creating `app/robots.ts` and `app/sitemap.ts` files that export functions returning `MetadataRoute.Robots` and `MetadataRoute.Sitemap` respectively, rather than relying on static files in the `public` directory. Hardcoded deployment URLs (e.g. `https://packwise-indol.vercel.app`) are frequently used when env vars like `NEXT_PUBLIC_APP_URL` are not guaranteed.
+**Action:** Always prefer native Next.js App Router dynamic metadata files (`app/sitemap.ts` and `app/robots.ts`) for configuring site crawlability. Ensure they are cleanly separated into public vs private routes.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  // SEO Rationale: Protect private routes from search crawler indexing
+  // while explicitly allowing public landing and authentication pages.
+  const baseUrl = 'https://packwise-indol.vercel.app'
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login', '/claim/'],
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/inventory/',
+        '/luggage/',
+        '/trip/',
+        '/api/'
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,22 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // SEO Rationale: Provide a dynamic sitemap for search engines to
+  // efficiently discover and index the primary public routes.
+  const baseUrl = 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** 
Added dynamic `app/robots.ts` and `app/sitemap.ts` files using Next.js App Router's native metadata APIs.

🎯 **Why:** 
To explicitly define which paths are accessible to search engine crawlers. Specifically:
- `robots.ts` actively disallows indexing for private, authenticated paths (e.g., `/dashboard/`, `/settings/`, `/inventory/`, `/luggage/`, `/trip/`, `/api/`) while allowing public landing paths (`/`, `/login`, `/claim/`). 
- `sitemap.ts` builds a programmatic XML map to ensure crawlers can effectively discover key public entry points (`/` and `/login`).

📊 **Impact:** 
This prevents sensitive or dynamic user-specific pages from bleeding into search engine indices, while guaranteeing discovery and visibility for the application's top-level marketing pages. 

🔬 **Verification:** 
- Navigated locally to verify Next.js dynamically renders both endpoints correctly.
- Ran Next.js linting (`pnpm lint`) and TypeScript syntax checks (`pnpm exec tsc --noEmit`).
- Skipped irrelevant End-to-End tests but ensured the 48 core unit tests mapped successfully.

🔗 **References:** 
- https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots
- https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap

---
*PR created automatically by Jules for task [15485957122831755820](https://jules.google.com/task/15485957122831755820) started by @mvng*