### PR TITLE
🔍 Scout: Add dynamic sitemap and robots.txt to control crawl scope

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,25 @@
+import { MetadataRoute } from 'next'
+
+// Scout: Configure crawl scope to ensure search engines only index public-facing pages.
+// We explicitly disallow private routes (dashboard, settings, etc.) to prevent duplicate content
+// or attempting to crawl login-walled areas.
+export default function robots(): MetadataRoute.Robots {
+  const rawBaseUrl = 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login', '/claim/'],
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/inventory/',
+        '/luggage/',
+        '/trip/',
+        '/api/',
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next'
+
+// Scout: Generate a dynamic sitemap.xml to improve crawlability for search engines.
+// This ensures that the primary entry points to the application are discovered
+// efficiently and prioritized appropriately.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rawBaseUrl = 'https://packwise-indol.vercel.app'
+  const baseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** Added dynamic `app/robots.ts` and `app/sitemap.ts` files utilizing Next.js Metadata Route APIs. Included inline comments detailing the SEO purpose of each file.
🎯 **Why:** To improve search engine crawlability by explicitly defining entry points to public pages (Homepage, Login, Claim) while actively preventing crawlers from indexing private, authenticated, or sensitive API routes (`/dashboard/`, `/settings/`, `/api/`, etc.) which wastes crawl budget and can cause duplicate content issues.
📊 **Impact:** Ensures structured and prioritized indexing of public landing pages while safeguarding private app states from search engine caches.
🔬 **Verification:** Verify by running the dev server and visiting `/robots.txt` and `/sitemap.xml` directly to confirm the correct Next.js dynamic generation.
🔗 **References:** 
- [Next.js sitemap.xml](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)
- [Next.js robots.txt](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

---
*PR created automatically by Jules for task [15061858798616200987](https://jules.google.com/task/15061858798616200987) started by @mvng*