### PR TITLE
🔍 Scout: Add robots.txt and sitemap.xml for crawlability

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,19 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login', '/claim/'],
+      disallow: [
+        '/dashboard',
+        '/settings',
+        '/inventory',
+        '/luggage',
+        '/trip/',
+        '/api/'
+      ],
+    },
+    sitemap: 'https://packwise-indol.vercel.app/sitemap.xml',
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,18 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://packwise-indol.vercel.app',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: 'https://packwise-indol.vercel.app/login',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:**
Added dynamic generation of `robots.txt` and `sitemap.xml` using Next.js App Router metadata features (`app/robots.ts` and `app/sitemap.ts`).

🎯 **Why:**
To explicitly control crawler access and improve the indexability of public pages. This prevents search engines from indexing private authenticated routes (like `/dashboard`, `/settings`, etc.) while ensuring they can efficiently discover and index the public-facing pages (`/` and `/login`).

📊 **Impact:**
Improves SEO crawl efficiency, ensures sensitive pages aren't accidentally indexed, and provides search engines with a structured map of the site's public URLs.

🔬 **Verification:**
1. Run the local dev server (`npm run dev`).
2. Visit `http://localhost:3000/robots.txt` and verify it correctly allows `/` and `/login` while disallowing `/dashboard`, `/settings`, `/inventory`, `/luggage`, `/trip/`, and `/api/`.
3. Visit `http://localhost:3000/sitemap.xml` and verify it outputs valid XML with the production URLs.

🔗 **References:**
- https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots
- https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap

---
*PR created automatically by Jules for task [5546607600620196026](https://jules.google.com/task/5546607600620196026) started by @mvng*