### PR TITLE
🎨 Palette: Improve keyboard accessibility for trip member buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve keyboard accessibility of hover-revealed member avatars
+**Learning:** Found that custom tooltip designs combined with mouse hover interactions (`group-hover:block`, `group-hover:opacity-100`) on icon-only buttons entirely lock out keyboard users. In `TripMembersSection`, replacing native `title` attributes with built-in custom tooltips meant screen readers couldn't announce the action, and tab-navigators couldn't see the "X" button or the member name.
+**Action:** Always ensure that any custom tooltip or icon swap relying on a parent `.group` and `group-hover` is mirrored with `group-focus-within` utilities (e.g., `group-focus-within:opacity-100`, `group-focus-within:block`). Additionally, when removing a native `title` attribute, it must immediately be replaced with a semantic `aria-label`.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,16 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
-                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 ${
+                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer focus-visible:ring-red-500' : 'cursor-default'
               }`}
-              title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,8 +84,8 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
-            title="Add member"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:border-transparent"
+            aria-label="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -110,15 +110,15 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
-            title="Confirm"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+            aria-label="Confirm adding member"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
-            title="Cancel"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+            aria-label="Cancel adding member"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
💡 **What:** 
- Replaced native `title` attributes with semantic `aria-label`s on icon-only buttons (Remove member, Add member, Confirm, Cancel) in the `TripMembersSection`.
- Added clear `focus-visible` outline styling to all interactive buttons.
- Mirrored the existing `group-hover` interactions on the member avatars with `group-focus-within` utilities so that the custom tooltip and the "X" remove icon are visible during keyboard navigation.

🎯 **Why:** 
Previously, the member avatars relied entirely on mouse hover to reveal their name tooltips and the critical "X" removal action. Furthermore, several icon-only buttons relied on native `title` attributes, which are inconsistently announced by screen readers. These changes ensure keyboard-only users can fully manage trip members and screen reader users hear clear action labels.

📸 **Before/After:**
*(Visual changes are in the focus states and keyboard reveal states; mouse hover interactions remain identical)*
- **Before:** Tabbing to a member avatar showed a generic browser outline around the initial, with no tooltip or "X" visible.
- **After:** Tabbing to a member avatar hides the initial, shows the "X", displays the custom tooltip, and renders a clean blue/red focus ring.

♿ **Accessibility:**
- Improved screen reader support via explicit `aria-label`s.
- Improved discoverability for keyboard-only users via `group-focus-within`.
- Improved focus management with Tailwind's `focus-visible` utilities.

---
*PR created automatically by Jules for task [14042073118063698831](https://jules.google.com/task/14042073118063698831) started by @mvng*