### PR TITLE
⚡ Bolt: Batch database updates in cron reminder job to fix N+1 query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2025-03-18 - Cron Job N+1 Query Optimization
+**Learning:** Found a classic N+1 query bottleneck in `app/api/cron/send-reminders/route.ts` where it was updating `reminderSentAt` individually for each task inside a `for` loop (O(n) database operations).
+**Action:** Replaced the individual loop updates with a single `prisma.tripTask.updateMany` operation outside the loop (O(1) database operation). This is a common pattern to look out for in batch processing scripts or cron jobs within this codebase. Always use `updateMany` or `createMany` when possible instead of looping. Also ensure that code comments are added explaining the optimization.

--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -75,9 +75,15 @@ export async function GET(request: NextRequest) {
         console.log(`[CALENDAR] Calendar invite generated for task: ${task.title}`)
       }
 
-      // Mark as sent
-      await prisma.tripTask.update({
-        where: { id: task.id },
+
+    }
+
+    // ⚡ Bolt Performance Optimization:
+    // Replaced N+1 query pattern with a batched updateMany operation.
+    // Previously, this fired a database update for every single task inside the loop.
+    if (tasks.length > 0) {
+      await prisma.tripTask.updateMany({
+        where: { id: { in: tasks.map(t => t.id) } },
         data: { reminderSentAt: now }
       })
     }


### PR DESCRIPTION
💡 What: Replaced individual `await prisma.tripTask.update()` calls inside a loop with a single batched `await prisma.tripTask.updateMany()` operation.
🎯 Why: Resolves an N+1 query performance bottleneck. Previously, if there were 100 pending task reminders, the cron job would make 100 separate database calls to mark them as sent. Now, it makes exactly 1 database call.
📊 Impact: Reduces database update queries for this cron job from O(n) to O(1), drastically lowering database connection usage, network overhead, and execution time for the Vercel serverless function.
🔬 Measurement: Verified that tests pass via `pnpm test`. Code review confirmed correct behavior. Performance impact is inherently verifiable by reading the diff (1 DB call vs N).

---
*PR created automatically by Jules for task [8023135061710995468](https://jules.google.com/task/8023135061710995468) started by @mvng*