### PR TITLE
🎨 Palette: Improve TaskCard keyboard accessibility and ARIA labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+
+## 2024-05-22 - Replaced React Hover State with Tailwind CSS for Better Accessibility
+**Learning:** In interactive components like `TaskCard`, relying on React's `onMouseEnter`/`onMouseLeave` to control the visibility of action buttons (Edit/Delete) completely hides those buttons from keyboard users who cannot trigger mouse events.
+**Action:** When implementing hover-revealed action containers, replace JavaScript state with Tailwind's `group` on the parent container, and use `opacity-0 group-hover:opacity-100 focus-within:opacity-100` on the action container to ensure it natively appears for both mouse hover and keyboard focus-tabbing.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,21 +20,19 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? "Mark as not done" : "Mark as done"}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,18 +67,18 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
-            title="Edit task"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            aria-label="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
-            title="Delete task"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+            aria-label="Delete task"
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
💡 What: Replaced React state (`isHovered`) based hover interactions with CSS-based `group-hover` and `focus-within` in `TaskCard`. Added missing `aria-label`s to the three icon-only buttons (Status toggle, Edit, Delete). Added `focus-visible` ring styling to all interactive buttons.
🎯 Why: Keyboard users tabbing through the task list would focus on invisible buttons, as they couldn't trigger the `onMouseEnter` event. Relying on React state for hover styling can lead to accessibility pitfalls. Moving it to CSS fixes the issue securely without runtime JS overhead. Additionally, icon-only buttons need descriptive labels for screen readers.
📸 Before/After: Action buttons were invisible when navigating via keyboard Tab. Now, they visibly appear on focus with clean `focus-visible:ring-2` styles.
♿ Accessibility: Ensures full keyboard navigability via `focus-within` and comprehensive screen reader support through explicit `aria-label`s.

---
*PR created automatically by Jules for task [17422146935535608982](https://jules.google.com/task/17422146935535608982) started by @mvng*