### PR TITLE
🔍 Scout: Dynamic robots.txt and sitemap.xml generation

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-05-22 - [Dynamic Sitemap and Robots.txt]
+**Learning:** Native generation of `robots.txt` and `sitemap.xml` in Next.js App Router through `app/robots.ts` and `app/sitemap.ts` creates reliable SEO indexation control. Explicitly denying indexing to private routes (like `/dashboard` and `/settings`) via `robots.ts` prevents crawlers from wasting crawl budget on authenticated states or failing API routes. Using `process.env.NEXT_PUBLIC_APP_URL` alongside a hardcoded fallback ensures robust `baseUrl` generation across multiple deployment environments.
+**Action:** Always prefer dynamic `.ts` file generation over static `.xml`/`.txt` files in `public` for robots and sitemaps in Next.js to enable environment-aware URL construction and ensure correct index exclusion.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  // Use environment variable if available, otherwise fallback to known production URL
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return {
+    rules: {
+      userAgent: '*',
+      // Allow indexing of public-facing landing and auth pages for better search visibility
+      allow: ['/', '/login', '/claim/'],
+      // Prevent crawlers from indexing private authenticated application views to protect user data
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/inventory/',
+        '/luggage/',
+        '/trip/',
+        '/api/'
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Use environment variable if available, otherwise fallback to known production URL
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      // The homepage is the primary landing page and should be crawled most frequently
+      url: `${baseUrl}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      // The login page is public but changes less frequently than the homepage
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** 
Implemented native Next.js dynamic routing for `robots.txt` and `sitemap.xml` by creating `app/robots.ts` and `app/sitemap.ts`. The configurations prioritize crawling of public-facing landing and authentication pages while strictly disallowing crawlers from accessing private application routes (`/dashboard`, `/settings`, `/inventory`, `/luggage`, `/trip`, `/api`). The base URL logic utilizes `process.env.NEXT_PUBLIC_APP_URL` with a fallback to the production domain.

🎯 **Why:** 
Previously, the site lacked instructions for search engine crawlers, potentially wasting crawl budget on private/authenticated routes where bots would encounter 401s or redirects. This change actively guides Googlebot and other crawlers toward the meaningful, public landing pages while safeguarding private endpoints, improving the overall crawl efficiency and ensuring the correct pages are indexed.

📊 **Impact:** 
Directly improves search engine crawl efficiency and indexation control, preventing duplicate content issues or crawl budget waste on private application states.

🔬 **Verification:** 
- The files are correctly generated by Next.js Server Components.
- Verified Next.js compilation works locally (`tsc --noEmit` and `pnpm lint`).
- Passed all core application unit tests.
*(Note: Full Playwright E2E tests were bypassed during verification due to rate limits pulling the required Docker PostgreSQL image in the sandbox environment, but the isolated Next.js metadata compilation succeeded flawlessly).*

🔗 **References:** 
- [Next.js App Router Metadata Docs](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)
- [Google Search Central: Robots.txt](https://developers.google.com/search/docs/crawling-indexing/robots/intro)

---
*PR created automatically by Jules for task [3172992430023435738](https://jules.google.com/task/3172992430023435738) started by @mvng*