### PR TITLE
🎨 Palette: Add Escape key handlers and accessibility to modals and popovers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-24 - Handle Escape Key and Modal Accessibility
+**Learning:** Some custom popovers and modals lack keyboard accessibility for screen-readers and closing behavior using the `Escape` key. I discovered that components like `CalendarSyncDropdown` lacked `Escape` key event listeners, `aria-expanded` and semantic `menu` roles for the dropdown layout, and `PasteListModal` lacked an `Escape` key close handler.
+**Action:** When creating or modifying custom interactive popovers, modals, or dropdown menus, ensure they include an `Escape` key event listener to close the component, appropriate semantic roles (e.g., `role="menu"`, `role="menuitem"`), and `aria-expanded`/`aria-haspopup` attributes.

--- a/components/CalendarSyncDropdown.tsx
+++ b/components/CalendarSyncDropdown.tsx
@@ -16,8 +16,17 @@ export default function CalendarSyncDropdown({ tripId }: CalendarSyncDropdownPro
         setShowCalendarMenu(false)
       }
     }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setShowCalendarMenu(false)
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
     document.addEventListener('mousedown', handleClickOutside)
     return () => {
+
+      document.removeEventListener('keydown', handleKeyDown)
       document.removeEventListener('mousedown', handleClickOutside)
     }
   }, [])
@@ -25,6 +34,8 @@ export default function CalendarSyncDropdown({ tripId }: CalendarSyncDropdownPro
   return (
     <div className="relative" ref={calendarMenuRef}>
       <button
+        aria-expanded={showCalendarMenu}
+        aria-haspopup="true"
         onClick={() => setShowCalendarMenu(!showCalendarMenu)}
         className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all"
         title="Calendar Sync"
@@ -34,11 +45,12 @@ export default function CalendarSyncDropdown({ tripId }: CalendarSyncDropdownPro
       </button>
 
       {showCalendarMenu && (
-        <div className="absolute right-0 mt-2 w-64 bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden z-20">
+        <div role="menu" className="absolute right-0 mt-2 w-64 bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden z-20">
           <div className="p-3 bg-gray-50 border-b border-gray-100">
             <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Auto-updating</h3>
           </div>
           <a
+            role="menuitem"
             href={typeof window !== 'undefined' ? `webcal://${window.location.host}/api/calendar/${tripId}` : `/api/calendar/${tripId}`}
             className="block px-4 py-3 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700 border-b border-gray-100"
             onClick={() => setShowCalendarMenu(false)}
@@ -51,6 +63,7 @@ export default function CalendarSyncDropdown({ tripId }: CalendarSyncDropdownPro
             <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">One-time Export</h3>
           </div>
           <a
+            role="menuitem"
             href={`/api/calendar/${tripId}`}
             className="block px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700"
             onClick={() => setShowCalendarMenu(false)}

--- a/components/PasteListModal.tsx
+++ b/components/PasteListModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useTransition, useMemo } from 'react'
+import { useState, useTransition, useMemo, useEffect } from 'react'
 import { importItemsToTrip } from '@/actions/packing.actions'
 
 interface PasteListModalProps {
@@ -151,6 +151,15 @@ export default function PasteListModal({ tripId, onClose, onSuccess }: PasteList
   const [parsedItems, setParsedItems] = useState<ParsedItem[]>([])
   const [isPending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
+
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
 
   const handleParse = () => {
     const items = parsePastedText(pastedText)


### PR DESCRIPTION
💡 What: Added `Escape` key close handlers to `PasteListModal` and `CalendarSyncDropdown`, and added proper ARIA and semantic `menu` roles to the `CalendarSyncDropdown` popover elements.
🎯 Why: To ensure keyboard-only users and those navigating with screen readers can easily dismiss popovers and properly interact with the calendar sync dropdown menus.
📸 Before/After: N/A - visual design preserved.
♿ Accessibility: Ensures WCAG compliance for dropdown accessibility patterns by specifying `aria-haspopup`, `aria-expanded`, and properly handling keyboard navigation.

---
*PR created automatically by Jules for task [11654585510212429256](https://jules.google.com/task/11654585510212429256) started by @mvng*