### PR TITLE
🔍 Scout: [Technical SEO] Add dynamic robots.txt and sitemap.xml

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,19 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  // Use the canonical production domain.
+  const baseUrl = 'https://packwise-indol.vercel.app'
+  const url = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+
+  return {
+    rules: {
+      userAgent: '*',
+      // Allow indexing of public-facing marketing and authentication pages
+      allow: ['/', '/login', '/claim/'],
+      // Prevent crawlers from indexing private user data and API routes to save crawl budget and protect privacy
+      disallow: ['/dashboard', '/settings', '/inventory', '/luggage', '/trip/', '/api/'],
+    },
+    // Explicitly point to the dynamically generated sitemap for improved discoverability
+    sitemap: `${url}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Use the canonical production domain.
+  const baseUrl = 'https://packwise-indol.vercel.app'
+  const url = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+
+  return [
+    {
+      // The homepage is the primary entry point and deserves the highest crawl priority
+      url: `${url}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      // The login page is a secondary public entry point
+      url: `${url}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:**
Added dynamic Next.js App Router metadata routes (`app/robots.ts` and `app/sitemap.ts`) to programmatically generate `robots.txt` and `sitemap.xml`.

🎯 **Why:**
Without an explicit `robots.txt` or `sitemap.xml`, search crawlers may struggle to efficiently index the site. They might waste crawl budget exploring authenticated/private routes (like `/dashboard`) and miss the intended public entry points (like `/` or `/login`). 

📊 **Impact:**
- Ensures private user paths are omitted from search engines, protecting privacy and saving crawl budget.
- Submits structured URLs and crawl priorities via the Sitemap, speeding up discovery and indexation of the homepage and authentication routes.
- Keeps configuration in-code and natively leverages the Next.js `MetadataRoute` API.

🔬 **Verification:**
1. Confirmed both `app/robots.ts` and `app/sitemap.ts` files were generated correctly.
2. Verified unit tests run successfully without regressions.
3. Added inline comments to document the SEO rationale behind the implemented paths.

🔗 **References:**
- Next.js Documentation on [Metadata Files: sitemap.xml](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)
- Next.js Documentation on [Metadata Files: robots.txt](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

---
*PR created automatically by Jules for task [7387103111915263576](https://jules.google.com/task/7387103111915263576) started by @mvng*