### PR TITLE
docs: Add viral marketing and growth strategies document

### DIFF
--- a/GROWTH_IDEAS.md
+++ b/GROWTH_IDEAS.md
@@ -1,0 +1,60 @@
+# 🚀 Packwise Growth & Viral Marketing Strategies
+
+As a smart packing list app, Packwise has a unique opportunity to grow through user-generated content, collaboration, and high-utility social sharing. Here is a curated list of features and marketing ideas designed to drive viral user acquisition and engagement.
+
+## 1. 🔄 Built-In Viral Loops & Social Sharing
+
+### A. Shareable "Template" Lists
+- **The Feature:** Allow users to publish their packing lists publicly with a unique URL (e.g., `packwise.app/templates/jane-europe-summer`).
+- **The Hook:** When viewers visit the link, they see a beautiful, interactive list. To check items off or save the template for their own trip, they must create a free account.
+- **Growth Impact:** Turns every highly organized traveler into an ambassador.
+
+### B. "Export for Stories" (Instagram/TikTok/Pinterest)
+- **The Feature:** A 1-click button to export a packing list into an aesthetic, vertical image or video format (e.g., a "Checklist" graphic).
+- **The Hook:** Includes a subtle watermark and a "Get my full list template on Packwise" call-to-action (CTA) for creators to put in their link-in-bio.
+- **Growth Impact:** Piggybacks off the massive travel content ecosystem on TikTok and IG.
+
+## 2. 🤝 Collaboration & Multiplayer
+
+### A. Collaborative Trip Packing
+- **The Feature:** Let users invite friends or family to a shared trip via a simple SMS or email link.
+- **The Hook:** "Jane invited you to pack for 'Vegas 2024'. Join to see who is bringing the sunscreen."
+- **Growth Impact:** Instant, high-intent referrals. Every group trip brings in 2-10 new users.
+
+### B. "Who's Bringing What?" Splitter
+- **The Feature:** For shared items (toothpaste, chargers, snacks), allow users to assign items to specific group members.
+- **Growth Impact:** Forces group adoption. If one person uses the app, the whole group needs it to coordinate.
+
+## 3. 🌍 Community & User-Generated Content (UGC)
+
+### A. Public Destination Guides
+- **The Feature:** Aggregate user data (anonymously) to create SEO-optimized landing pages like "The Ultimate Packing List for Backpacking Japan in October."
+- **The Hook:** These pages index on Google and capture high-intent search traffic ("what to pack for japan").
+- **Growth Impact:** Sustainable, long-term organic search acquisition.
+
+### B. Influencer / Creator Storefronts
+- **The Feature:** Allow travel creators to build their "Packwise Profile" featuring all their gear.
+- **The Hook:** Creators can add Amazon Affiliate links to their items. Packwise splits the revenue or lets them keep 100% to drive platform adoption.
+- **Growth Impact:** Incentivizes influencers to heavily promote their Packwise links.
+
+## 4. 🎮 Gamification & Engagement
+
+### A. "Preparedness Score" & AI Roasts
+- **The Feature:** Use the AI to scan a user's list and give it a score (e.g., "85/100").
+- **The Hook:** "You're going to London in November and didn't pack an umbrella? Bold move." Let users share their "AI Roast" on Twitter/Threads.
+- **Growth Impact:** Highly shareable, humorous content that demonstrates the AI's value.
+
+### B. Packing Personality Badges
+- **The Feature:** Award users badges based on their packing habits (e.g., "The Minimalist" for <20 items, "The Overpacker", "The Last-Minute Legend").
+- **Growth Impact:** Identity-driven sharing. People love sharing personality-type results on social media (Spotify Wrapped effect).
+
+## 5. 🔗 Strategic Integrations
+
+### A. Email Forwarding (TripIt Style)
+- **The Feature:** Users forward their flight or Airbnb confirmation to `trips@packwise.app`.
+- **The Hook:** The app automatically creates a trip, reads the destination/dates, checks the weather, and generates a smart packing list instantly.
+- **Growth Impact:** "Aha!" moment friction is reduced to zero.
+
+### B. Airbnb / Booking.com Chrome Extension
+- **The Feature:** A browser extension that prompts "Start packing for this trip?" when a user books a flight or accommodation.
+- **Growth Impact:** Captures users at the exact moment of intent.


### PR DESCRIPTION
I have brainstormed and documented a variety of growth ideas and viral marketing strategies tailored specifically for Packwise. These are stored in a new file, `GROWTH_IDEAS.md`, in the root of the project.

Ideas include:
1.  **Built-In Viral Loops**: Shareable public packing templates and "Export for Stories".
2.  **Multiplayer Features**: Collaborative trips and item assignments for groups.
3.  **Community & UGC**: Public SEO destination guides and influencer storefronts with affiliate links.
4.  **Gamification**: AI "Preparedness score" roasts and packing personality badges.
5.  **Strategic Integrations**: Email forwarding (TripIt style) and browser extensions for booking sites.

Tests and linter verified no regressions were introduced.

---
*PR created automatically by Jules for task [8147145397909783244](https://jules.google.com/task/8147145397909783244) started by @mvng*