### PR TITLE
🎨 Palette: [UX improvement] Enhance TaskCard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+
+## 2024-05-18 - Replacing React Hover State with Tailwind CSS for Better Accessibility
+**Learning:** In the `TaskCard` component, hover actions were previously revealed using React state (`onMouseEnter`/`onMouseLeave`). While this works visually for mouse users, it completely hides the actions from keyboard-only users who navigate via `Tab`, making them inaccessible.
+**Action:** When implementing hidden action menus or buttons that appear on hover, prefer Tailwind's `group` and `group-hover:opacity-100` coupled with `focus-within:opacity-100`. This ensures zero JavaScript overhead and allows the hidden actions to correctly appear when a user tabs into the container.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,21 +20,19 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? "Mark task as incomplete" : "Mark task as done"}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,18 +67,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
+            aria-label="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
+            aria-label="Delete task"
           >
             <Trash2 className="w-4 h-4" />
           </button>

--- a/components/TripPlanningAssistant/TaskForm.tsx
+++ b/components/TripPlanningAssistant/TaskForm.tsx
@@ -73,7 +73,8 @@ export default function TaskForm({ initialTask, onSave, onCancel, startDate }: T
         <button
           type="button"
           onClick={onCancel}
-          className="p-1 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors"
+          className="p-1 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+          aria-label="Close task form"
         >
           <X className="w-5 h-5" />
         </button>


### PR DESCRIPTION
### 💡 What
Improved the keyboard accessibility and screen reader support for the `TaskCard` and `TaskForm` components within the Trip Planning Assistant.

### 🎯 Why
Previously, the action buttons (edit, delete) on the `TaskCard` were only visible on mouse hover (`onMouseEnter`/`onMouseLeave` React state). This made them completely inaccessible to keyboard users navigating via `Tab`. Furthermore, the icon-only buttons lacked proper `aria-label`s, making them confusing for screen reader users.

### 📸 Before/After
*(See Playwright verification screenshots in the PR)*
- **Before:** Action buttons hidden from keyboard users. No visible focus rings on icon buttons.
- **After:** Tabbing into a task card now reveals the action buttons. All action buttons have clear blue/red focus rings when focused.

### ♿ Accessibility
- Replaced JS hover state with Tailwind `group-hover:opacity-100` and `focus-within:opacity-100` to support keyboard navigation.
- Added descriptive `aria-label`s to the status toggle, edit, delete, and form close buttons.
- Added `focus-visible:ring-2` to all modified buttons to ensure clear focus indicators.

---
*PR created automatically by Jules for task [11728057818158269296](https://jules.google.com/task/11728057818158269296) started by @mvng*