### PR TITLE
🎨 Palette: Enhance accessibility for icon-only action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Enhance accessible icon-only hover buttons
+**Learning:** Found a specific a11y issue pattern where dynamically mapped lists (like `PackingListSection.tsx` categories) had inline icon-only action buttons (e.g., `X` to cancel edit or delete item) that appeared within hover groups but were missing `aria-label`s, preventing screen readers from understanding the action. Furthermore, keyboard users tabbing through the list could focus the buttons, but without explicit `focus:ring-2` styles, the active element was visually ambiguous.
+**Action:** When adding hover-revealed action buttons within list rows, always ensure they include explicit descriptive `aria-label`s and `focus-visible` or `focus:ring` utility classes to support discovery by screen reader and keyboard-only users.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -727,7 +727,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                       }}
                       className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-300" aria-label="Cancel editing note"><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -748,6 +748,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
             <button
               onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
               title="Add/Edit Note"
+              aria-label="Add or Edit Note"
               className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
             ><MessageSquare className="w-3.5 h-3.5" /></button>
             <button
@@ -1243,7 +1244,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                             }}
                                             className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
                                           ><Check className="w-3 h-3" /></button>
-                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                                          <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-300" aria-label="Cancel editing note"><X className="w-3 h-3" /></button>
                                         </div>
                                       </div>
                                     ) : item.notes ? (
@@ -1263,14 +1264,16 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                   <button
                                     onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
                                     title="Add/Edit Note"
+                                    aria-label="Add or Edit Note"
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
                                   ><MessageSquare className="w-3.5 h-3.5" /></button>
                                   <button
                                     onClick={() => handleTogglePackLast(item.id, category.id, list.id, item.packLast)}
                                     title="Add to departure checklist"
+                                    aria-label="Add to departure checklist"
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center"
                                   ><Sunrise className="w-3.5 h-3.5" /></button>
-                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
+                                  <button onClick={() => handleDelete(item.id, category.id, list.id)} aria-label="Delete item" className="text-red-400 hover:text-red-600 text-xs focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"><X className="w-4 h-4" /></button>
                                 </div>
                               )}
                             </li>

--- a/components/PlanningBoardView.tsx
+++ b/components/PlanningBoardView.tsx
@@ -497,7 +497,7 @@ function DayColumn({
               <span className="text-sm">{allDayTag.icon}</span>
               <span className={`text-[11px] font-semibold ${headerText} opacity-90`}>{allDayTag.label}</span>
               <span className={`text-[10px] ml-0.5 opacity-50 ${headerText}`}>— all day</span>
-              <button onClick={() => saveLabel('')} className={`ml-auto text-[11px] opacity-60 hover:opacity-100 ${headerText} focus:outline-none leading-none`}>✕</button>
+              <button onClick={() => saveLabel('')} aria-label="Clear label" className={`ml-auto text-[11px] opacity-60 hover:opacity-100 ${headerText} focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-400 rounded leading-none`}>✕</button>
             </div>
           ) : editingLabel ? (
             <input autoFocus type="text" value={labelInput}


### PR DESCRIPTION
💡 What: Added missing `aria-label`s and `focus:ring-2` utility classes to inline icon-only action buttons (such as cancel, delete, and edit note buttons) across mapping components.
🎯 Why: Screen readers could not announce the purpose of these buttons because they lacked accessible names. Additionally, when navigating via keyboard (tabbing), these buttons lacked visual focus indicators, making it hard to discern which element was currently active.
📸 Before/After: N/A - visual change is only apparent on focus (`Tab` key).
♿ Accessibility: Ensures that interactive icon elements are fully discoverable and comprehensible to assistive technologies and keyboard-only users.

---
*PR created automatically by Jules for task [10390250641785831132](https://jules.google.com/task/10390250641785831132) started by @mvng*