### PR TITLE
🔍 Scout: Add robots.txt and sitemap.xml

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Generating a robots.txt helps crawlers understand which pages to index and which to ignore.
+// We explicitly disallow private authenticated routes and backend APIs to prevent search engines
+// from indexing user-specific data or trying to crawl non-public pages, optimizing crawl budget.
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login', '/claim/'],
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/inventory/',
+        '/luggage/',
+        '/trip/',
+        '/api/'
+      ],
+    },
+    sitemap: 'https://packwise-indol.vercel.app/sitemap.xml',
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Adding a sitemap.xml ensures search engines can efficiently discover and index
+// the primary public pages of the application (Home and Login).
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://packwise-indol.vercel.app'
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** Added dynamic `robots.txt` and `sitemap.xml` files using Next.js App Router's `MetadataRoute`.

🎯 **Why:** To improve search engine visibility and control crawl behavior. The site previously lacked both files. The `robots.txt` explicitly disallows private routes (like `/dashboard/`, `/settings/`, `/inventory/`, `/luggage/`, `/trip/`, and `/api/`) to prevent search engines from trying to index authenticated content, saving crawl budget. The `sitemap.xml` explicitly lists the primary public entry points (`/` and `/login`) to assist crawlers in discovering the main pages.

📊 **Impact:** Improves SEO crawlability by ensuring search engines correctly discover the site's public structure and prevents indexing of sensitive or dynamic user-specific pages.

🔬 **Verification:** 
- The files were generated dynamically via Next.js and build perfectly.
- Verified test suite using `pnpm test` with mocked database credentials.
- Reviewed the generated contents to verify hardcoded `baseUrl` and path directives align with the application's structure.

🔗 **References:** 
- Next.js Documentation: [Robots and Sitemap Metadata](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)
- Google Search Central: [Intro to robots.txt](https://developers.google.com/search/docs/crawling-indexing/robots/intro)

---
*PR created automatically by Jules for task [1039646572027895373](https://jules.google.com/task/1039646572027895373) started by @mvng*