### PR TITLE
🔍 Scout: [SEO improvement] Add robots.txt and sitemap.xml

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,21 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = 'https://packwise-indol.vercel.app'
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/login', '/claim/'],
+      disallow: [
+        '/dashboard',
+        '/settings',
+        '/inventory',
+        '/luggage',
+        '/trip/',
+        '/api/',
+      ],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://packwise-indol.vercel.app'
+
+  // We are currently only exposing the main public marketing and auth pages.
+  // Dynamic claim pages are intentionally left out of the sitemap.xml because
+  // they are ephemeral/unique to users, but they remain crawlable if linked.
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** Added Next.js `robots.ts` and `sitemap.ts` files to explicitly define crawler indexing rules and provide an XML sitemap of the main public pages (`/` and `/login`).
🎯 **Why:** To improve search engine visibility for public pages while ensuring private, authenticated app routes (`/dashboard`, `/settings`, `/inventory`, etc.) are explicitly blocked from being indexed. This provides crawlers with a clear structure of the site's intended footprint.
📊 **Impact:** Enhances crawl efficiency and improves indexing coverage of the core landing and authentication pages. Prevents potential duplicate content or thin content issues that could arise from crawlers accessing app-specific routes.
🔬 **Verification:** The Next.js dev server successfully compiles the files. You can navigate to `/robots.txt` and `/sitemap.xml` in the browser to view the correctly generated outputs.
🔗 **References:** 
- https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots
- https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap

---
*PR created automatically by Jules for task [16263100366001819033](https://jules.google.com/task/16263100366001819033) started by @mvng*