### PR TITLE
⚡ Bolt: Optimize Day Plan Sync Database Queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2024-05-28 - Optimized API Sync Performance with Bulk Query
+**Learning:** In `app/api/day-plans/sync/route.ts`, an N+1 query problem was causing a separate database request for every item during synchronization. However, when combining items for a batch `$transaction`, duplicate items created in the same batch could cause conflicts.
+**Action:** Replaced iterative loops containing `findMany`, `update`, and `create` calls inside a map loop with `prisma.$transaction()` using accumulated Promise objects. Used a Map to deduplicate items first to prevent `write conflicts`. By accessing the related items data that had already been brought to memory using `include: { items: true }`, the `findMany` request could be fully removed.

--- a/app/api/day-plans/sync/route.ts
+++ b/app/api/day-plans/sync/route.ts
@@ -37,6 +37,12 @@ export async function POST(req: Request) {
     let maxCatOrder = existingCategories.reduce((max, c) => Math.max(max, c.order), -1)
     let synced = 0
 
+    // ⚡ Bolt Performance Optimization
+    // Why: Eliminated N+1 queries by replacing in-loop item fetches with the already included
+    // `category.items`, and batched all item creates/updates into a single transaction.
+    // Impact: Reduces database roundtrips from potentially hundreds down to 1.
+    const operations: any[] = []
+
     for (const [catName, items] of grouped) {
       let category = existingCategories.find(
         (c) => c.name.toLowerCase() === catName.toLowerCase()
@@ -48,39 +54,58 @@ export async function POST(req: Request) {
           data: { packingListId: packingList.id, name: catName, order: maxCatOrder },
           include: { items: true },
         })
+        existingCategories.push(category)
       }
 
-      const existingItems = await prisma.packingItem.findMany({
-        where: { categoryId: category.id },
-        orderBy: { order: 'desc' },
-      })
+      const existingItems = category.items || []
       let maxItemOrder = existingItems.reduce((max, i) => Math.max(max, i.order), -1)
 
+      // Deduplicate intra-batch items to prevent transaction write conflicts
+      const itemMap = new Map<string, { quantity: number; originalName: string }>()
       for (const item of items) {
-        const existing = existingItems.find(
-          (i) => i.name.toLowerCase() === item.name.toLowerCase()
-        )
+        const nameKey = item.name.toLowerCase()
+        const currentQty = itemMap.get(nameKey)?.quantity || 0
+        itemMap.set(nameKey, {
+          quantity: Math.max(currentQty, item.quantity),
+          originalName: item.name
+        })
+      }
+
+      for (const [nameKey, { quantity, originalName }] of itemMap.entries()) {
+        const existing = existingItems.find((i) => i.name.toLowerCase() === nameKey)
         if (existing) {
-          await prisma.packingItem.update({
-            where: { id: existing.id },
-            data: { quantity: Math.max(existing.quantity, item.quantity) },
-          })
+          const newQuantity = Math.max(existing.quantity, quantity)
+          if (newQuantity > existing.quantity) {
+            operations.push(
+              prisma.packingItem.update({
+                where: { id: existing.id },
+                data: { quantity: newQuantity },
+              })
+            )
+            existing.quantity = newQuantity
+          }
         } else {
           maxItemOrder += 1
-          await prisma.packingItem.create({
-            data: {
-              categoryId: category.id,
-              name: item.name,
-              quantity: item.quantity,
-              isPacked: false,
-              isCustom: true,
-              packLast: false,
-              order: maxItemOrder,
-            },
-          })
+          operations.push(
+            prisma.packingItem.create({
+              data: {
+                categoryId: category.id,
+                name: originalName,
+                quantity: quantity,
+                isPacked: false,
+                isCustom: true,
+                packLast: false,
+                order: maxItemOrder,
+              },
+            })
+          )
           synced++
         }
       }
+    }
+
+    if (operations.length > 0) {
+      await prisma.$transaction(operations)
     }
 
     return NextResponse.json({ synced })


### PR DESCRIPTION
💡 What: Eliminated N+1 database queries during day plan sync by using already-fetched relations (`category.items`) and batching all `create` and `update` operations into a single `prisma.$transaction`. We also implemented an in-memory `Map` to deduplicate intra-batch items, avoiding write conflicts.
🎯 Why: Synchronizing a day plan with many items created individual database queries for every single item inside a loop. The database was hit iteratively, resulting in terrible scale and an N+1 loop constraint problem.
📊 Impact: Reduces database roundtrips for syncing items from potentially hundreds down to exactly 1 transaction (or 0 if no changes are needed), heavily speeding up the endpoint and reducing load on the database.
🔬 Measurement: Ran the automated test suite using mocked database env variables to ensure core functionality around categories and items is preserved. Checked `git diff` to ensure logic completeness. Code linter continues to pass perfectly without any regressions.

---
*PR created automatically by Jules for task [5576926826370363876](https://jules.google.com/task/5576926826370363876) started by @mvng*