### PR TITLE
🔍 Scout: [Technical SEO] Add robots.txt and sitemap.xml

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next'
+
+// Defines the crawler rules for the site to ensure private pages are not indexed
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/dashboard/',
+        '/settings/',
+        '/inventory/',
+        '/luggage/',
+        '/trip/',
+        '/api/'
+      ],
+    },
+    sitemap: 'https://packwise-indol.vercel.app/sitemap.xml',
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,19 @@
+import { MetadataRoute } from 'next'
+
+// Generates the sitemap.xml to improve crawlability of public routes
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://packwise-indol.vercel.app',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: 'https://packwise-indol.vercel.app/login',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
💡 **What:** Created `app/robots.ts` and `app/sitemap.ts` using Next.js Metadata API.
🎯 **Why:** To prevent search engines from crawling private authenticated routes (like `/dashboard` or `/api`) which wastes crawl budget, and to provide an explicit sitemap for public routes (`/` and `/login`) to improve their discoverability and indexing speed.
📊 **Impact:** Optimizes crawl budget, prevents duplicate/unauthorized indexing of private routes, and gives search crawlers a clear map of public pages.
🔬 **Verification:** Validated that both `robots.txt` and `sitemap.xml` are correctly structured via code review. Confirmed they do not break existing application behavior and pass all tests.
🔗 **References:** 
- Next.js Metadata API: `robots.ts` (https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots) 
- Next.js Metadata API: `sitemap.ts` (https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

---
*PR created automatically by Jules for task [11858982401383007512](https://jules.google.com/task/11858982401383007512) started by @mvng*