### PR TITLE
⚡ Bolt: Fix N+1 queries in day plan sync API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+## 2023-10-27 - [Batching Write Operations with Prisma $transaction in Loops]
+**Learning:** When trying to resolve an N+1 problem by batching `update` and `create` operations into an array for `prisma.$transaction(writeOperations)`, be aware that if the payload iterates over user-submitted data containing duplicates (e.g., duplicate packing items), it can cause Prisma errors if the transaction attempts to create or update the exact same duplicate item multiple times within the exact same batch.
+**Action:** Always deduplicate iterative payloads (e.g., using a Map or Set) before pushing their operations into a `$transaction` array.

--- a/app/api/day-plans/sync/route.ts
+++ b/app/api/day-plans/sync/route.ts
@@ -37,6 +37,8 @@ export async function POST(req: Request) {
     let maxCatOrder = existingCategories.reduce((max, c) => Math.max(max, c.order), -1)
     let synced = 0
 
+    const writeOperations = []
+
     for (const [catName, items] of grouped) {
       let category = existingCategories.find(
         (c) => c.name.toLowerCase() === catName.toLowerCase()
@@ -50,37 +52,54 @@ export async function POST(req: Request) {
         })
       }
 
-      const existingItems = await prisma.packingItem.findMany({
-        where: { categoryId: category.id },
-        orderBy: { order: 'desc' },
-      })
+      // Deduplicate payload items within the same category to prevent Prisma $transaction errors
+      const deduplicatedItems = new Map<string, typeof items[0]>()
+      for (const item of items) {
+        const key = item.name.toLowerCase()
+        if (deduplicatedItems.has(key)) {
+          deduplicatedItems.get(key)!.quantity = Math.max(deduplicatedItems.get(key)!.quantity, item.quantity)
+        } else {
+          deduplicatedItems.set(key, { ...item })
+        }
+      }
+
+      // We already have existing items in category.items thanks to the include directive
+      const existingItems = category.items || []
       let maxItemOrder = existingItems.reduce((max, i) => Math.max(max, i.order), -1)
 
-      for (const item of items) {
+      for (const item of deduplicatedItems.values()) {
         const existing = existingItems.find(
           (i) => i.name.toLowerCase() === item.name.toLowerCase()
         )
         if (existing) {
-          await prisma.packingItem.update({
-            where: { id: existing.id },
-            data: { quantity: Math.max(existing.quantity, item.quantity) },
-          })
+          writeOperations.push(
+            prisma.packingItem.update({
+              where: { id: existing.id },
+              data: { quantity: Math.max(existing.quantity, item.quantity) },
+            })
+          )
         } else {
           maxItemOrder += 1
-          await prisma.packingItem.create({
-            data: {
-              categoryId: category.id,
-              name: item.name,
-              quantity: item.quantity,
-              isPacked: false,
-              isCustom: true,
-              packLast: false,
-              order: maxItemOrder,
-            },
-          })
+          writeOperations.push(
+            prisma.packingItem.create({
+              data: {
+                categoryId: category.id!, // using ! to bypass typescript complaint, we know category exists
+                name: item.name,
+                quantity: item.quantity,
+                isPacked: false,
+                isCustom: true,
+                packLast: false,
+                order: maxItemOrder,
+              },
+            })
+          )
           synced++
         }
       }
+    }
+
+    if (writeOperations.length > 0) {
+      await prisma.$transaction(writeOperations)
     }
 
     return NextResponse.json({ synced })


### PR DESCRIPTION
### 💡 What
Refactored `app/api/day-plans/sync/route.ts` to solve an N+1 database querying issue. 
- Removed repeated internal `prisma.packingItem.findMany` calls and replaced them with pre-fetched `category.items` relational data.
- Deduplicated incoming item payloads.
- Batched all `prisma.packingItem.update` and `prisma.packingItem.create` calls into an array and executed them via a single `prisma.$transaction`.

### 🎯 Why
In the previous implementation, syncing a Day Plan triggered a new read query for every packing list category, and subsequently triggered individual write queries (updates/creates) for every single item inside nested loops. For large trips, this meant potentially hundreds of synchronous database round trips, heavily throttling performance.

### 📊 Impact
Reduces database query count from `O(N)` queries (where N is the number of items) down to `O(1)` batched queries. Specifically, replaces an `n`-length sequence of individual database writes with a single `prisma.$transaction()`, vastly accelerating response times.

### 🔬 Measurement
Verified by running the test suite (`pnpm test`), passing all tests, including pre-existing mock verifications, ensuring correct quantities and duplicate item handling via deduplication logic.

---
*PR created automatically by Jules for task [3307420045756807764](https://jules.google.com/task/3307420045756807764) started by @mvng*