### PR TITLE
🔍 Scout: Fix Next.js Open Graph URL inheritance for dynamic routes

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-05-29 - Next.js openGraph.url Inheritance Quirk
+**Learning:** Hardcoding `url: 'https://example.com'` in the root `layout.tsx` `openGraph` object forces all child routes to inherit this exact absolute URL for their OG tag, breaking social sharing on dynamic or nested routes. In Next.js App Router, it's better to rely on `metadataBase` combined with relative `alternates.canonical` and `openGraph.url` definitions on individual routes.
+**Action:** When setting up global metadata in Next.js, define `metadataBase` in the root layout but avoid setting an absolute `url` in the root `openGraph` object. Instead, set relative `url` properties on child routes.

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -1,9 +1,13 @@
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
+  alternates: {
+    canonical: '/login',
+  },
   title: 'Sign In or Create Account | Packwise',
   description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   openGraph: {
+    url: '/login',
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   },

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -34,6 +34,7 @@ export async function generateMetadata({
 
     const titleName = list.name || list.trip.name || list.trip.destination || 'Untitled Trip'
     const title = `Join the Packing List for ${titleName} | Packwise`
+    const url = '/claim/' + resolvedParams.token;
     const description = list.trip.destination
       ? `Join the shared packing list for ${list.trip.destination}. Claim the items you're bringing!`
       : `Join this shared packing list on Packwise. Claim the items you're bringing!`
@@ -41,9 +42,13 @@ export async function generateMetadata({
     return {
       title,
       description,
+      alternates: {
+        canonical: url,
+      },
       openGraph: {
         title,
         description,
+        url,
         type: 'website',
       },
       twitter: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,6 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,15 @@
+
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    url: '/',
+  },
+}
+
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'

--- a/app/trip/[id]/layout.tsx
+++ b/app/trip/[id]/layout.tsx
@@ -23,6 +23,7 @@ export async function generateMetadata({
 
     const titleName = trip.name || trip.destination || 'Untitled Trip'
     const title = `${titleName} Packing List | Packwise`
+    const url = '/trip/' + resolvedParams.id;
     const description = trip.destination
       ? `Check out the packing list for ${trip.destination}. Organized and ready for the trip!`
       : `Check out this packing list on Packwise. Organized and ready for the trip!`
@@ -30,9 +31,13 @@ export async function generateMetadata({
     return {
       title,
       description,
+      alternates: {
+        canonical: url,
+      },
       openGraph: {
         title,
         description,
+        url,
         type: 'website',
       },
       twitter: {


### PR DESCRIPTION
💡 **What:** 
Removed the hardcoded absolute `url` from the root `app/layout.tsx` `openGraph` object and added relative `alternates.canonical` and `openGraph.url` properties to `app/page.tsx`, `app/(auth)/login/layout.tsx`, `app/claim/[token]/page.tsx`, and `app/trip/[id]/layout.tsx`. (Note: `metadataBase` was already correctly set in the root layout).

🎯 **Why:** 
In Next.js App Router, hardcoding an absolute URL in the root `openGraph` metadata forces all child routes to inherit that exact URL. This was breaking social sharing for dynamic pages like `/claim/[token]` and `/trip/[id]`, as unfurls were pointing back to the homepage instead of the specific shared list. 

📊 **Impact:** 
Improves CTR and user experience when users share specific packing lists via messaging apps and social media, as the link unfurl will now correctly point to the specific route instead of the homepage.

🔬 **Verification:** 
- `pnpm lint` passed.
- `pnpm test` passed.
- Visually verified metadata generation logic inside `app/claim/[token]/page.tsx` and `app/trip/[id]/layout.tsx`.

🔗 **References:** 
- Next.js Metadata Object: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadata-object

---
*PR created automatically by Jules for task [6334405091516576840](https://jules.google.com/task/6334405091516576840) started by @mvng*