### PR TITLE
⚡ Bolt: Optimize day-plans sync API with transaction and reduced queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2025-03-18 - Replacing N+1 loops with pre-fetched relations and Transactions
+**Learning:** In deeply nested sync APIs like `app/api/day-plans/sync/route.ts`, looping over arrays to perform individual Prisma queries (like `await prisma.packingItem.findMany` per category or individual `update`/`create` commands) creates significant N+1 network overhead. It is much faster to fetch the relational data on the parent object (`category.items`), compute the diff in memory, and accumulate the resulting Prisma `Promise`s into a `operations` array to execute in one batched `prisma.$transaction`.
+**Action:** When seeing `await prisma.*` inside a `for` loop, refactor it by pre-fetching the necessary data using `include`, performing updates/creates conditionally in memory, and appending the un-awaited Prisma promises to a transaction array. Ensure there are no duplicate IDs inside the transaction batch by deduplicating inputs first.

--- a/app/api/day-plans/sync/route.ts
+++ b/app/api/day-plans/sync/route.ts
@@ -25,7 +25,14 @@ export async function POST(req: Request) {
     for (const item of allItems) {
       const key = item.category ?? 'General'
       if (!grouped.has(key)) grouped.set(key, [])
-      grouped.get(key)!.push(item)
+
+      const itemsList = grouped.get(key)!
+      const existingInGroup = itemsList.find((i) => i.name.toLowerCase() === item.name.toLowerCase())
+      if (existingInGroup) {
+        existingInGroup.quantity = Math.max(existingInGroup.quantity, item.quantity)
+      } else {
+        itemsList.push({ ...item })
+      }
     }
 
     const existingCategories = await prisma.category.findMany({
@@ -36,6 +43,7 @@ export async function POST(req: Request) {
 
     let maxCatOrder = existingCategories.reduce((max, c) => Math.max(max, c.order), -1)
     let synced = 0
+    const operations: any[] = []
 
     for (const [catName, items] of grouped) {
       let category = existingCategories.find(
@@ -48,12 +56,10 @@ export async function POST(req: Request) {
           data: { packingListId: packingList.id, name: catName, order: maxCatOrder },
           include: { items: true },
         })
+        existingCategories.push(category)
       }
 
-      const existingItems = await prisma.packingItem.findMany({
-        where: { categoryId: category.id },
-        orderBy: { order: 'desc' },
-      })
+      const existingItems = category.items || []
       let maxItemOrder = existingItems.reduce((max, i) => Math.max(max, i.order), -1)
 
       for (const item of items) {
@@ -61,26 +67,36 @@ export async function POST(req: Request) {
           (i) => i.name.toLowerCase() === item.name.toLowerCase()
         )
         if (existing) {
-          await prisma.packingItem.update({
-            where: { id: existing.id },
-            data: { quantity: Math.max(existing.quantity, item.quantity) },
-          })
+          if (item.quantity > existing.quantity) {
+            operations.push(
+              prisma.packingItem.update({
+                where: { id: existing.id },
+                data: { quantity: item.quantity },
+              })
+            )
+          }
         } else {
           maxItemOrder += 1
-          await prisma.packingItem.create({
-            data: {
-              categoryId: category.id,
-              name: item.name,
-              quantity: item.quantity,
-              isPacked: false,
-              isCustom: true,
-              packLast: false,
-              order: maxItemOrder,
-            },
-          })
+          operations.push(
+            prisma.packingItem.create({
+              data: {
+                categoryId: category.id,
+                name: item.name,
+                quantity: item.quantity,
+                isPacked: false,
+                isCustom: true,
+                packLast: false,
+                order: maxItemOrder,
+              },
+            })
+          )
           synced++
         }
       }
+    }
+
+    if (operations.length > 0) {
+      await prisma.$transaction(operations)
     }
 
     return NextResponse.json({ synced })


### PR DESCRIPTION
💡 **What**: Refactored `app/api/day-plans/sync/route.ts` to deduplicate items in memory, eliminate a nested N+1 `findMany` query inside the category loop, and batch all `INSERT` and `UPDATE` operations into a single `prisma.$transaction`.

🎯 **Why**: Previously, the sync route executed a database query to find items for every category and individually awaited `update` or `create` mutations. For lists with many items and categories, this resulted in dozens of database round-trips.

📊 **Impact**: This dramatically reduces network overhead, turning O(N) database queries into a single `findMany` and a single `$transaction`, making syncing significantly faster and more scalable for users with large item lists.

🔬 **Measurement**: Verified by ensuring the `pnpm lint` and `pnpm test` (Playwright suite) pass successfully, confirming the sync logic preserves correctness while dramatically reducing the number of database queries executed.

---
*PR created automatically by Jules for task [1141531440554525395](https://jules.google.com/task/1141531440554525395) started by @mvng*