### PR TITLE
🎨 Palette: Add focus visible rings for CategorySection buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2026-05-30 - Add keyboard focus rings to interactive buttons
+**Learning:** Found that many interactive buttons (e.g. "Add item", options menu, favorite toggle, edit/delete actions) in the inventory `CategorySection` lacked keyboard focus styling (`focus-visible:`), making keyboard navigation difficult for users as they could not see which element had focus.
+**Action:** Always ensure that interactive elements like buttons have explicit `focus-visible` utility classes (e.g., `focus-visible:ring-2`, `focus-visible:outline-none`) so keyboard users can track their focus.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -37,14 +37,14 @@ export default function CategorySection({
         <div className="flex items-center gap-3">
           <button
             onClick={onAddItem}
-            className="text-sm text-blue-500 hover:text-blue-600 font-medium transition-colors"
+            className="text-sm text-blue-500 hover:text-blue-600 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded px-1"
           >
             + Add item
           </button>
           <div className="relative">
             <button
               onClick={() => setShowMenu((v) => !v)}
-              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none"
+              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded"
               aria-label="Category options"
             >
               •••
@@ -58,7 +58,7 @@ export default function CategorySection({
                       onDeleteCategory()
                       setShowMenu(false)
                     }}
-                    className="w-full text-left px-4 py-2.5 text-sm text-red-600 hover:bg-red-50 transition-colors"
+                    className="w-full text-left px-4 py-2.5 text-sm text-red-600 hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:bg-red-50 focus-visible:ring-2 focus-visible:ring-red-500"
                   >
                     Delete category
                   </button>
@@ -75,7 +75,7 @@ export default function CategorySection({
           <p className="text-sm text-gray-400">No items yet.</p>
           <button
             onClick={onAddItem}
-            className="mt-1.5 text-sm text-blue-500 hover:text-blue-600 font-medium transition-colors"
+            className="mt-1.5 text-sm text-blue-500 hover:text-blue-600 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded px-2 py-1"
           >
             Add your first item
           </button>
@@ -89,7 +89,7 @@ export default function CategorySection({
                 onClick={() => onToggleFavorite(item)}
                 disabled={isPending}
                 title={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50"
+                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 rounded-full"
               >
                 {item.isFavorite ? (
                   '⭐'
@@ -118,7 +118,7 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  className="p-1.5 text-gray-400 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-lg hover:bg-gray-100 transition-colors"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +138,7 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  className="p-1.5 text-gray-400 hover:text-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What:
Added explicit `focus-visible` styling (`focus-visible:outline-none`, `focus-visible:ring-2`) and complementary colors (e.g., `ring-blue-500`, `ring-yellow-400`, `ring-red-500`) to interactive elements (add, options menu, favorite, edit, delete buttons) within the `CategorySection` inventory component.

🎯 Why:
Many interactive icon and text buttons in the inventory lacked visible focus indicators, making it nearly impossible for keyboard-only or screen reader users to track which element they had navigated to. Adding focus rings solves this critical accessibility issue.

📸 Before/After:
Before: Tabbing through the category list resulted in no visual changes on the buttons.
After: Tabbing clearly highlights the currently focused button with an appropriate colored ring.

♿ Accessibility:
Fixes WCAG 2.4.7 (Focus Visible) violations by ensuring all interactive actions provide clear visual feedback when receiving keyboard focus.

---
*PR created automatically by Jules for task [4604769143437357355](https://jules.google.com/task/4604769143437357355) started by @mvng*