### PR TITLE
🎨 Palette: Enhance keyboard and screen reader accessibility for Category list actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-30 - Improve accessibility of list item action buttons
+**Learning:** Found a pattern where hover-revealed action buttons (like edit and delete) in dynamic lists were using `title` tooltips but lacked proper `aria-label`s and `focus-visible` states, making them undiscoverable for screen readers and keyboard-only users.
+**Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes (interpolating context like item name) and explicit `focus-visible:outline-none focus-visible:ring-2` utility classes so screen reader and keyboard users can discover and trigger them properly.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -89,7 +89,9 @@ export default function CategorySection({
                 onClick={() => onToggleFavorite(item)}
                 disabled={isPending}
                 title={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50"
+                aria-label={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+                aria-pressed={item.isFavorite}
+                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 rounded-full"
               >
                 {item.isFavorite ? (
                   '⭐'
@@ -118,7 +120,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +141,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 **What:** Added `aria-label`, `aria-pressed`, and `focus-visible` styling to the favorite, edit, and delete icon buttons within the `CategorySection` component.
🎯 **Why:** These actions previously relied on `title` attributes for tooltips, but lacked explicit `aria-label`s for screen readers and did not have proper `focus-visible` states, making them undiscoverable for keyboard-only and screen reader users navigating the dynamic list.
📸 **Before/After:** Not visually apparent on mouse hover, but tab-navigating keyboard users now see distinct focus rings (yellow for favorite, gray for edit, red for delete) for previously hidden list items actions.
♿ **Accessibility:** Provides accessible screen reader context interpolated with the item name, and adds clear visible focus rings.

---
*PR created automatically by Jules for task [10418433532922111845](https://jules.google.com/task/10418433532922111845) started by @mvng*