### PR TITLE
🔍 Scout: [Add noindex to private claim token pages]

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-03-24 - [Noindex Private Share Tokens]
+**Learning:** Added `robots: { index: false, follow: false }` to the `generateMetadata` function of the dynamic `/claim/[token]` route. This correctly signals search engines not to index these private, single-use token pages, avoiding duplicate content penalties and protecting shared list privacy.
+**Action:** Always ensure that private, token-based, or user-specific share pages use the Next.js `robots` metadata property to enforce `noindex, nofollow`, as public discoverability is actively harmful for these route types.

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -8,6 +8,11 @@ import type { Metadata } from 'next'
 // Adding dynamic metadata to the claim page ensures that when users share this link
 // via social media or messaging apps, the Open Graph preview accurately reflects
 // the trip destination and context, significantly improving click-through rates.
+
+// SCOUT SEO RATIONALE:
+// Adding robots: { index: false, follow: false } ensures that these private, single-use
+// claim token pages are not crawled or indexed by search engines. This prevents duplicate
+// content issues and protects user privacy for shared packing lists.
 export async function generateMetadata({
   params,
 }: {
@@ -29,7 +34,11 @@ export async function generateMetadata({
       return {
         title: 'Shared Packing List | Packwise',
         description: 'Join this shared packing list on Packwise.',
-      }
+      robots: {
+        index: false,
+        follow: false,
+      },
+    }
     }
 
     const titleName = list.name || list.trip.name || list.trip.destination || 'Untitled Trip'
@@ -50,6 +59,10 @@ export async function generateMetadata({
         card: 'summary_large_image',
         title,
         description,
+      },
+      robots: {
+        index: false,
+        follow: false,
       },
     }
   } catch (error) {


### PR DESCRIPTION
💡 **What:** Added `robots: { index: false, follow: false }` to the `generateMetadata` function of the dynamic `/claim/[token]` route.

🎯 **Why:** Claim token pages are private, single-use invites designed for specific individuals to join a shared packing list. They contain duplicate UI and should not be crawled or indexed by search engines. Adding `noindex` prevents index bloat, avoids duplicate content penalties, and protects the privacy of shared trips.

📊 **Impact:** Prevents unintended public discoverability of private share URLs in Google Search results and protects site-wide crawl budget.

🔬 **Verification:** Verified that the code cleanly applies the Next.js `robots` directive to the metadata export, ran `pnpm lint` and `pnpm test` successfully.

🔗 **References:** 
- Next.js Metadata API: https://nextjs.org/docs/app/building-your-application/optimizing/metadata
- Google Search Central Docs on robots meta tags: https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag

---
*PR created automatically by Jules for task [17288201660239879585](https://jules.google.com/task/17288201660239879585) started by @mvng*