### PR TITLE
🎨 Palette: Add accessibility to all-day tag clear button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-12 - Add accessibility to all-day tag clear button
+**Learning:** Found an icon-only '✕' button in `components/PlanningBoardView.tsx` used to clear the all-day tag that lacked an `aria-label` and keyboard focus styling.
+**Action:** When implementing clear or remove buttons, especially icon-only ones, always ensure they have an `aria-label` describing their action and explicit `focus-visible:ring-2` utility classes for keyboard accessibility.

--- a/components/PlanningBoardView.tsx
+++ b/components/PlanningBoardView.tsx
@@ -497,7 +497,7 @@ function DayColumn({
               <span className="text-sm">{allDayTag.icon}</span>
               <span className={`text-[11px] font-semibold ${headerText} opacity-90`}>{allDayTag.label}</span>
               <span className={`text-[10px] ml-0.5 opacity-50 ${headerText}`}>— all day</span>
-              <button onClick={() => saveLabel('')} className={`ml-auto text-[11px] opacity-60 hover:opacity-100 ${headerText} focus:outline-none leading-none`}>✕</button>
+              <button aria-label="Clear all-day tag" onClick={() => saveLabel('')} className={`ml-auto text-[11px] opacity-60 hover:opacity-100 ${headerText} focus:outline-none focus-visible:ring-2 focus-visible:ring-current rounded leading-none`}>✕</button>
             </div>
           ) : editingLabel ? (
             <input autoFocus type="text" value={labelInput}


### PR DESCRIPTION
💡 **What:** Added an `aria-label` and keyboard focus styling to the "✕" icon button that clears the all-day tag in the planning board.

🎯 **Why:** The button was icon-only without a descriptive label, making it invisible to screen readers. It also lacked focus styling, making it difficult for keyboard users to navigate to and interact with it.

📸 **Before/After:**
*   **Before:** `<button onClick={() => saveLabel('')} className="...">✕</button>`
*   **After:** `<button aria-label="Clear all-day tag" onClick={() => saveLabel('')} className="... focus-visible:ring-2 focus-visible:ring-current rounded">✕</button>`

♿ **Accessibility:**
*   Added `aria-label="Clear all-day tag"` for screen reader support.
*   Added `focus-visible:ring-2 focus-visible:ring-current focus-visible:outline-none rounded` for visible keyboard focus states.

---
*PR created automatically by Jules for task [18234424783842095802](https://jules.google.com/task/18234424783842095802) started by @mvng*