### PR TITLE
🔍 Scout: Fix inherited absolute OpenGraph URLs & Canonical Tags

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-06-02 - [Avoid Hardcoded URLs in Root Layout]
+**Learning:** In Next.js App Router, hardcoding an absolute `openGraph.url` in the root `app/layout.tsx` metadata configuration forces all child routes to incorrectly inherit that exact URL (unless explicitly overridden), breaking social sharing functionality and SEO consistency for nested pages. Setting a relative `alternates.canonical` (e.g., `'/'`) in the root layout causes similar inheritance issues.
+**Action:** Remove hardcoded absolute URLs and relative canonicals from root layouts. Rely strictly on `metadataBase` in the root, and define relative `alternates.canonical` and `openGraph.url` values explicitly within individual route segments (like `app/page.tsx`, `app/login/layout.tsx`, etc.).

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -3,9 +3,13 @@ import { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Sign In or Create Account | Packwise',
   description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
+  alternates: {
+    canonical: '/login',
+  },
   openGraph: {
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
+    url: '/login',
   },
 }
 

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -29,6 +29,12 @@ export async function generateMetadata({
       return {
         title: 'Shared Packing List | Packwise',
         description: 'Join this shared packing list on Packwise.',
+        alternates: {
+          canonical: `/claim/${resolvedParams.token}`,
+        },
+        openGraph: {
+          url: `/claim/${resolvedParams.token}`,
+        },
       }
     }
 
@@ -41,10 +47,14 @@ export async function generateMetadata({
     return {
       title,
       description,
+      alternates: {
+        canonical: `/claim/${resolvedParams.token}`,
+      },
       openGraph: {
         title,
         description,
         type: 'website',
+        url: `/claim/${resolvedParams.token}`,
       },
       twitter: {
         card: 'summary_large_image',
@@ -56,6 +66,12 @@ export async function generateMetadata({
     return {
       title: 'Shared Packing List | Packwise',
       description: 'Join this shared packing list on Packwise.',
+      alternates: {
+        canonical: `/claim/${resolvedParams.token}`,
+      },
+      openGraph: {
+        url: `/claim/${resolvedParams.token}`,
+      },
     }
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,6 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,15 @@
+
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    url: '/',
+  },
+}
+
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'


### PR DESCRIPTION
💡 **What:** Removed the hardcoded absolute `openGraph.url` from the root `app/layout.tsx` metadata and explicitly defined relative `alternates.canonical` and `openGraph.url` attributes on the Homepage (`app/page.tsx`), Login Page (`app/(auth)/login/layout.tsx`), and dynamic Claim pages (`app/claim/[token]/page.tsx`).

🎯 **Why:** In Next.js App Router, metadata is inherited. Because the root `layout.tsx` hardcoded the homepage URL as the `openGraph.url`, every single child route in the application falsely reported the homepage URL to social media platforms and crawlers. By moving the explicit URLs to the individual page segments, we ensure correct link unfurling and crawler visibility for all routes.

📊 **Impact:** Prevents canonicalization and Open Graph inheritance issues across the entire application. Social shares of dynamic links (like shared packing lists) will now correctly link to the specific page rather than redirecting unfurls to the homepage.

🔬 **Verification:** `pnpm test` and `pnpm lint` both pass cleanly. The Next.js compiler correctly outputs the distinct canonical tags per route.

🔗 **References:** [Next.js Metadata Object and generateMetadata Documentation](https://nextjs.org/docs/app/building-your-application/optimizing/metadata)

---
*PR created automatically by Jules for task [16675946889924346418](https://jules.google.com/task/16675946889924346418) started by @mvng*