### PR TITLE
🎨 Palette: Add aria-labels and focus states to inventory actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-02 - Add aria-labels and keyboard focus to Inventory actions
+**Learning:** Found a pattern where hover-revealed action buttons (like Edit/Delete in `CategorySection.tsx`) omit `aria-label` attributes for icon-only SVGs and lack explicit keyboard focus indicators, rendering them undiscoverable and unusable for keyboard and screen reader users. Also observed that fixing test mocks requires modifying the module export (`prismaModule.prisma`) instead of the read-only imported proxy object.
+**Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes (e.g. `aria-label={"Edit ${item.name}"}`) and explicit `focus-visible` utility classes (e.g., `focus-visible:ring-blue-500`) so screen reader and keyboard users can discover and trigger them reliably.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -118,7 +118,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +139,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
                 >
                   <svg
                     className="w-3.5 h-3.5"

--- a/tests/save-to-inventory.test.ts
+++ b/tests/save-to-inventory.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { POST } from '../app/api/day-plan-items/save-to-inventory/route';
-import { prisma } from '../lib/prisma';
+import * as prismaModule from '../lib/prisma';
 import * as auth from '../lib/supabase/server';
 import { NextResponse } from 'next/server';
 
@@ -51,10 +51,7 @@ test.describe('Performance: save-to-inventory', () => {
       }
     };
 
-    Object.defineProperty(prisma, 'user', { value: mockPrisma.user, configurable: true });
-    Object.defineProperty(prisma, 'dayPlan', { value: mockPrisma.dayPlan, configurable: true });
-    Object.defineProperty(prisma, 'inventoryCategory', { value: mockPrisma.inventoryCategory, configurable: true });
-    Object.defineProperty(prisma, 'inventoryItem', { value: mockPrisma.inventoryItem, configurable: true });
+    Object.defineProperty(prismaModule, 'prisma', { value: mockPrisma, configurable: true });
 
     // Mock Supabase Auth
     Object.defineProperty(auth, 'createClient', { configurable: true,


### PR DESCRIPTION
💡 What: Added dynamic `aria-label`s and `focus-visible` utility classes to the Edit and Delete buttons in the Inventory `CategorySection.tsx` component.
🎯 Why: To make these critical item-level actions discoverable for screen reader users and usable for keyboard-only navigation, as they were previously only discoverable on mouse hover without focus rings or semantic text. Fixed a broken Prisma mock in a test suite to ensure robust verification.
📸 Before/After: Screenshots captured and verified during Playwright testing showing the new focus rings on the action buttons.
♿ Accessibility: Ensures interactive buttons are perceivable by screen readers by using the item's name (e.g. `Edit Shoes`), and operable by keyboard users via explicit sequential tab focus styling.

---
*PR created automatically by Jules for task [15396146059173689552](https://jules.google.com/task/15396146059173689552) started by @mvng*