### PR TITLE
⚡ Bolt: Optimize day plan sync to prevent N+1 queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2025-03-25 - Safe In-Memory Traversal of Prisma Includes
+**Learning:** When attempting to remove an N+1 `prisma.findMany()` call from inside a loop by using a pre-fetched relation (`category.items`), it is absolutely critical to verify that the parent query *actually included* that relation (e.g., `include: { items: true }`). If the relation was not included, `category.items` will be undefined, leading to runtime failures or data duplication.
+**Action:** Always verify the original Prisma query includes the required relational fields before replacing database calls with in-memory traversal of those relations.

--- a/app/api/day-plans/sync/route.ts
+++ b/app/api/day-plans/sync/route.ts
@@ -37,6 +37,11 @@ export async function POST(req: Request) {
     let maxCatOrder = existingCategories.reduce((max, c) => Math.max(max, c.order), -1)
     let synced = 0
 
+    // ⚡ Bolt Performance Optimization:
+    // Accumulate all packing item updates and creates into a single transaction
+    // to prevent N+1 queries during day plan syncing.
+    const dbOperations: any[] = []
+
     for (const [catName, items] of grouped) {
       let category = existingCategories.find(
         (c) => c.name.toLowerCase() === catName.toLowerCase()
@@ -50,37 +55,61 @@ export async function POST(req: Request) {
         })
       }
 
-      const existingItems = await prisma.packingItem.findMany({
-        where: { categoryId: category.id },
-        orderBy: { order: 'desc' },
-      })
+      // Use pre-fetched items rather than querying inside the loop
+      const existingItems = category.items || []
       let maxItemOrder = existingItems.reduce((max, i) => Math.max(max, i.order), -1)
 
+      // Deduplicate items to prevent intra-transaction conflicts
+      const deduplicatedItems = new Map<string, { name: string, quantity: number }>()
       for (const item of items) {
+        const nameKey = item.name.toLowerCase()
+        const current = deduplicatedItems.get(nameKey)
+        if (!current) {
+          deduplicatedItems.set(nameKey, { name: item.name, quantity: item.quantity })
+        } else {
+          current.quantity = Math.max(current.quantity, item.quantity)
+        }
+      }
+
+      for (const [nameKey, itemData] of deduplicatedItems) {
         const existing = existingItems.find(
-          (i) => i.name.toLowerCase() === item.name.toLowerCase()
+          (i) => i.name.toLowerCase() === nameKey
         )
+
         if (existing) {
-          await prisma.packingItem.update({
-            where: { id: existing.id },
-            data: { quantity: Math.max(existing.quantity, item.quantity) },
-          })
+          // Only update if quantity needs to be increased
+          if (itemData.quantity > existing.quantity) {
+            dbOperations.push(
+              prisma.packingItem.update({
+                where: { id: existing.id },
+                data: { quantity: itemData.quantity },
+              })
+            )
+            // Update in-memory in case it's checked again (not strictly necessary here but good practice)
+            existing.quantity = itemData.quantity
+          }
         } else {
           maxItemOrder += 1
-          await prisma.packingItem.create({
-            data: {
-              categoryId: category.id,
-              name: item.name,
-              quantity: item.quantity,
-              isPacked: false,
-              isCustom: true,
-              packLast: false,
-              order: maxItemOrder,
-            },
-          })
+          dbOperations.push(
+            prisma.packingItem.create({
+              data: {
+                categoryId: category.id,
+                name: itemData.name,
+                quantity: itemData.quantity,
+                isPacked: false,
+                isCustom: true,
+                packLast: false,
+                order: maxItemOrder,
+              },
+            })
+          )
           synced++
         }
       }
+    }
+
+    if (dbOperations.length > 0) {
+      await prisma.$transaction(dbOperations)
     }
 
     return NextResponse.json({ synced })


### PR DESCRIPTION
💡 What
Accumulated `prisma.packingItem.update` and `prisma.packingItem.create` operations into an array and batched them with `prisma.$transaction()`, while deduplicating operations and removing a redundant `findMany` inside the synchronization loop.

🎯 Why
When syncing a day plan containing many items back to the main packing list, the application was executing individual `findMany`, `create`, and `update` queries inside a `for` loop, causing an N+1 database bottleneck.

📊 Impact
Dramatically reduces the number of database queries during a sync operation, especially for large day plans, improving API response times and preventing potential transaction timeouts.

🔬 Measurement
Review the `app/api/day-plans/sync/route.ts` API latency using Vercel Speed Insights or trace it directly; verify that bulk sync operations execute near instantly instead of scaling linearly with the number of day plan items.

---
*PR created automatically by Jules for task [10173861193901932256](https://jules.google.com/task/10173861193901932256) started by @mvng*