### PR TITLE
🎨 Palette: Improve keyboard accessibility for Trip Members section

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve TripMembersSection tooltip accessibility
+**Learning:** Found that avatar tooltips and icon actions in `TripMembersSection` were styled using only `group-hover`, making them invisible to keyboard focus users, and the avatar buttons lacked `aria-label` definitions for screen readers.
+**Action:** When creating hover-activated tooltips or action icons, always include `group-focus-within` styling alongside `group-hover` to ensure keyboard accessibility. Also, explicitly define `aria-label`s on any interactive elements that convey meaning primarily through visual cues like names or avatars.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -59,15 +59,16 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
               className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
-                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
+                isOwner ? 'hover:bg-red-100 hover:text-red-600 focus-visible:bg-red-100 focus-visible:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 cursor-pointer' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}


### PR DESCRIPTION
💡 What:
Added explicit focus states (`focus-visible`) and updated `aria-label`s to the remove member buttons in `TripMembersSection`. Additionally, modified the tooltip and remove icon to be visible when the element is focused via keyboard (`group-focus-within`), not just on mouse hover.

🎯 Why:
The 'remove member' action and tooltip were previously only discoverable and visible to mouse users who hovered over the avatar. Keyboard-only users and screen readers had no clear indication of the button's action or current focus state, leading to a poor accessibility experience. This ensures all users can discover and trigger the action.

📸 Before/After:
Before: Hover-only icon and tooltip, no focus ring.
After: Visible focus ring, tooltip and 'X' icon appear on both hover and focus.

♿ Accessibility:
- Added descriptive `aria-label` to the member pill buttons.
- Added `focus-visible:ring-2`, `focus-visible:ring-red-500`, and `focus-visible:bg-red-100` classes to the remove button.
- Replaced hover-only `group-hover:hidden`/`group-hover:block` logic with `group-hover:hidden group-focus-within:hidden` and `group-hover:block group-focus-within:block` respectively.

---
*PR created automatically by Jules for task [17486920415402990263](https://jules.google.com/task/17486920415402990263) started by @mvng*