### PR TITLE
🔍 Scout: Fix absolute OpenGraph URL and add relative canonicals

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-03-16 - [Root Canonical Anti-Pattern]
+**Learning:** In Next.js App Router, hardcoding a relative `alternates.canonical` or an absolute `openGraph.url` in the root `app/layout.tsx` forces all child routes to inherit it, causing them to falsely report the homepage as their canonical URL, breaking social sharing and SEO for nested pages.
+**Action:** Always set `metadataBase` in the root layout but omit `alternates.canonical` and `openGraph.url`. Define these strings explicitly on individual routes (e.g., `app/page.tsx` or `app/login/layout.tsx`) to prevent incorrect inheritance.

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -1,9 +1,16 @@
 import { Metadata } from 'next'
 
+// SCOUT SEO RATIONALE:
+// Defining relative `alternates.canonical` and `openGraph.url` locally ensures
+// proper canonical resolution and distinct Open Graph previews for the login route.
 export const metadata: Metadata = {
+  alternates: {
+    canonical: '/login',
+  },
   title: 'Sign In or Create Account | Packwise',
   description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   openGraph: {
+    url: '/login',
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,6 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,22 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 
+import type { Metadata } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Defining relative `alternates.canonical` and `openGraph.url` at the route level
+// rather than the root layout ensures that child pages do not incorrectly inherit
+// the homepage URL, preserving correct Open Graph and canonical tags for all routes.
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    url: '/',
+  },
+}
+
+
 export default async function HomePage() {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()


### PR DESCRIPTION
💡 **What**: Removed the hardcoded `openGraph.url` from the root `app/layout.tsx` and defined relative `alternates.canonical` and `openGraph.url` at the route level in `app/page.tsx` and `app/(auth)/login/layout.tsx`.
🎯 **Why**: In Next.js App Router, metadata inherited from root forces all child routes to falsely report the homepage URL, breaking Open Graph unfurling and causing SEO duplicate content issues. Setting relative URLs at the individual route fixes this.
📊 **Impact**: Fixes SEO duplicate penalties and improves accurate Open Graph metadata generation for deep links.
🔬 **Verification**: Code review passed and tested locally using `pnpm lint` and `pnpm test`.
🔗 **References**: Next.js Metadata documentation on inheritance.

---
*PR created automatically by Jules for task [12312039079517700083](https://jules.google.com/task/12312039079517700083) started by @mvng*