### PR TITLE
🎨 Palette: Add keyboard focus states to inventory actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Enhance keyboard accessibility of hover-revealed action buttons
+**Learning:** Found a persistent pattern where action buttons (like Edit/Delete) inside lists (e.g. `CategorySection.tsx`) rely on parent `group-hover:opacity-100` for visibility. While parent containers sometimes have `focus-within:opacity-100`, the interactive buttons themselves frequently lack explicit `focus-visible` utility classes and `aria-label`s, rendering them completely invisible to keyboard tab navigation.
+**Action:** When creating or modifying lists with hover-only row actions, always ensure the individual interactive elements (buttons) include explicit `focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2` styles and valid `aria-label` attributes to support keyboard-only users and screen readers.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -118,7 +118,7 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label="Edit item" className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none focus-visible:opacity-100"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +138,7 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label="Delete item" className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:outline-none focus-visible:opacity-100"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
### 💡 What
Added explicit `focus-visible` states and `aria-label` attributes to the "Edit item" and "Delete item" icon-only buttons in the Inventory `CategorySection` component.

### 🎯 Why
Previously, these buttons were only visible via mouse hover (`group-hover:opacity-100`). While the parent container supported `focus-within:opacity-100`, the buttons themselves lacked explicit focus styles and ARIA labels. This meant keyboard users had no visual feedback when tabbing through the list, and screen readers could not interpret the purpose of the icon-only buttons. 

### 📸 Before/After
**Before:** Tabbing to an item in the inventory list provided no visual indication of which button was focused.
**After:** Tabbing to an item reveals the buttons, and the active button displays a clear, semantic focus ring (gray for edit, red for delete).

### ♿ Accessibility
- Added `focus-visible:ring-2 focus-visible:outline-none focus-visible:opacity-100` to ensure keyboard discoverability.
- Added descriptive `aria-label="Edit item"` and `aria-label="Delete item"` attributes for screen reader compatibility.

---
*PR created automatically by Jules for task [11483771503361387514](https://jules.google.com/task/11483771503361387514) started by @mvng*