### PR TITLE
⚡ Bolt: Optimize DB query payload on progress route

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2025-03-24 - Prisma Include Cartesian Product Avoidance
+**Learning:** In Next.js Server Actions or route handlers, over-fetching with `include: { items: true }` when calculating simple aggregates like "total" and "packed" causes unnecessary serialization and DB transfer overhead.
+**Action:** Always prefer targeted `select` statements to retrieve only the fields needed for the computation (e.g., `quantity` and `isPacked`) to avoid serializing complete records, unless the full record is needed by the client.

--- a/app/api/trips/[id]/progress/route.ts
+++ b/app/api/trips/[id]/progress/route.ts
@@ -28,14 +28,25 @@ export async function GET(
       return NextResponse.json({ error: 'Trip not found' }, { status: 404 })
     }
 
+    // ⚡ Bolt Performance Optimization
+    // Why: Switched from `include: { items: true }` to a targeted `select`.
+    // Impact: Drastically reduces the database payload and Node serialization overhead.
+    // We only fetch the required fields (name, quantity, isPacked) for progress calculation,
+    // instead of bringing thousands of items with full columns into memory.
     const categories = await prisma.category.findMany({
       where: {
         packingList: {
           tripId: id
         }
       },
-      include: {
-        items: true
+      select: {
+        name: true,
+        items: {
+          select: {
+            quantity: true,
+            isPacked: true
+          }
+        }
       }
     })
 


### PR DESCRIPTION
💡 What: Modified the Prisma query in `app/api/trips/[id]/progress/route.ts` to use a targeted `select` instead of `include: { items: true }` when calculating packing list progress.
🎯 Why: The original query over-fetched every column from the `PackingItem` table (like `id`, `notes`, `categoryId`, etc.) into Node memory just to access the `quantity` and `isPacked` fields, causing unnecessary memory allocation and increasing DB network payload.
📊 Impact: Considerably reduces the serialized payload size and memory parsing time, especially for trips containing many packing items.
🔬 Measurement: Verify locally via dev tools network tab that `/api/trips/[id]/progress` execution overhead is reduced when calculating percentages for large packing lists. Tests pass as no observable changes occur to the endpoint result.

---
*PR created automatically by Jules for task [17505442380304553183](https://jules.google.com/task/17505442380304553183) started by @mvng*