### PR TITLE
🎨 Palette: Fix keyboard accessibility for hover-revealed dashboard actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-04 - Fix keyboard accessibility for hover-revealed dashboard actions
+**Learning:** Found a specific pattern where action buttons are hidden by default and only visible via `opacity-0 group-hover:opacity-100`. These buttons become inaccessible for keyboard navigation since they do not become visible when focused, hiding essential actions from screen readers and keyboard users.
+**Action:** When creating or modifying hover-revealed action buttons, always ensure the parent container includes `focus-within:opacity-100` and individual buttons contain proper focus rings `focus-visible:outline-none focus-visible:ring-2` to support full keyboard accessibility.

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -157,10 +157,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 flex gap-1 transition-opacity">
+      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-1 transition-opacity">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -168,7 +168,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
@@ -200,10 +200,10 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
+      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Edit trip"
         >
           <Edit2 className="w-4 h-4" />
@@ -211,7 +211,7 @@ export default function DashboardClient({
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center"
+          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
           aria-label="Delete trip"
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}


### PR DESCRIPTION
💡 What: Added `focus-within:opacity-100` to the hover-revealed action button containers in the Dashboard, and injected explicit `focus-visible` rings on the individual buttons.
🎯 Why: Hover-revealed actions (like Edit/Delete on trip cards) using `group-hover:opacity-100` are completely invisible and undiscoverable for users navigating via keyboard. The buttons must become visible when a user tabs into them.
📸 Before/After: Before, keyboard users tabbing through the dashboard would focus on invisible elements, not knowing Edit/Delete buttons existed for their trips. After, tabbing into the trip card's action buttons makes the entire button group visible and provides a clear outline focus ring.
♿ Accessibility: Ensures critical Trip actions are accessible to non-mouse users and screen readers navigating sequentially.

---
*PR created automatically by Jules for task [1899777677244605138](https://jules.google.com/task/1899777677244605138) started by @mvng*