### PR TITLE
🔍 Scout: Fix inherited Open Graph URLs and canonical tags across nested routes

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-06-04 - [Next.js Canonical URL and OG URL Inheritance]
+**Learning:** In Next.js App Router, hardcoding an absolute `openGraph.url` or a relative `alternates.canonical` in the root `layout.tsx` forces all child routes to falsely inherit it, breaking SEO and social sharing for nested pages.
+**Action:** Set `metadataBase` in the root layout, but define relative `alternates.canonical` and `openGraph.url` strings specifically on individual routes.

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -3,7 +3,11 @@ import { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Sign In or Create Account | Packwise',
   description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
+  alternates: {
+    canonical: '/login',
+  },
   openGraph: {
+    url: '/login',
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   },

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -29,6 +29,12 @@ export async function generateMetadata({
       return {
         title: 'Shared Packing List | Packwise',
         description: 'Join this shared packing list on Packwise.',
+        alternates: {
+          canonical: `/claim/${resolvedParams.token}`,
+        },
+        openGraph: {
+          url: `/claim/${resolvedParams.token}`,
+        },
       }
     }
 
@@ -41,7 +47,11 @@ export async function generateMetadata({
     return {
       title,
       description,
+      alternates: {
+        canonical: `/claim/${resolvedParams.token}`,
+      },
       openGraph: {
+        url: `/claim/${resolvedParams.token}`,
         title,
         description,
         type: 'website',
@@ -56,6 +66,12 @@ export async function generateMetadata({
     return {
       title: 'Shared Packing List | Packwise',
       description: 'Join this shared packing list on Packwise.',
+      alternates: {
+        canonical: `/claim/${resolvedParams.token}`,
+      },
+      openGraph: {
+        url: `/claim/${resolvedParams.token}`,
+      },
     }
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,6 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,15 @@
+
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    url: '/',
+  },
+}
+
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'


### PR DESCRIPTION
💡 **What:**
Removed the absolute `openGraph.url` from the root `app/layout.tsx` (retaining `metadataBase`), and explicitly defined relative `alternates.canonical` and `openGraph.url` strings on individual routes (`/`, `/login`, and dynamic share pages like `/claim/[token]`).

🎯 **Why:**
In Next.js App Router, hardcoding an absolute `openGraph.url` or a relative `alternates.canonical` in the root `layout.tsx` forces all child routes to falsely inherit it, breaking SEO and social sharing for nested pages.

📊 **Impact:**
Fixes link unfurling and social sharing for dynamic pages (like the `claim/[token]` page) and ensures search engines index the correct canonical URL for nested routes.

🔬 **Verification:**
Manually tested running Playwright end-to-end tests after modifications. Verified metadata correctly propagates on nested routes.

🔗 **References:**
https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase

---
*PR created automatically by Jules for task [510536919856360308](https://jules.google.com/task/510536919856360308) started by @mvng*