### PR TITLE
✨ Feature: Add Growth & Viral Marketing Strategy document

### DIFF
--- a/GROWTH_IDEAS.md
+++ b/GROWTH_IDEAS.md
@@ -1,0 +1,50 @@
+# 🚀 Packwise Growth & Viral Marketing Strategy
+
+As a marketing guru and viral social media expert, here are the top product features and marketing campaigns designed to ignite user growth, build network effects, and create viral loops for Packwise.
+
+## 🌟 1. Core Viral Product Features (Network Effects)
+
+### 🧳 Shareable "Trip Aesthetic" Cards (The "Spotify Wrapped" of Packing)
+* **What it is:** Instead of just exporting a list, generate a beautiful, highly-visual "Trip Summary" card optimized for Instagram Stories or TikTok.
+* **Viral Loop:** Users share their exciting upcoming trip (e.g., "Bali 2024 - 14 Days") along with a generated graphic showing their packing style (e.g., "The Minimalist", "The Overpacker", "The Prepared Pro"). The card includes a discrete watermark/link: *"Create your packing aesthetic with Packwise."*
+
+### 👯 Collaborative Group Packing Lists
+* **What it is:** The ability to invite friends to a shared packing list for group trips.
+* **Viral Loop:** One user plans a group trip and invites 5 friends to collaborate on "Shared Items" (who brings the sunscreen, speakers, adapters?). This forces 5 new users to sign up for the app to view and check off their responsibilities.
+
+### 📸 Creator & Influencer Public Templates
+* **What it is:** Allow users to publish their packing lists as public templates.
+* **Viral Loop:** Travel influencers and digital nomads can create lists like *"My 2-Week Japan Backpacking Essentials"* or *"Coachella Packing List"* and share the Packwise link in their bio or YouTube descriptions. This drives high-intent, organic traffic.
+
+### 💸 Affiliate Integration for Creators
+* **What it is:** Let users add their own Amazon or reward affiliate links to items in their public packing lists.
+* **Viral Loop:** Gives influencers a monetary incentive to build their packing lists *on Packwise* instead of a generic blog post, driving their entire audience to our platform.
+
+## 🎯 2. Social Media & Content Campaigns
+
+### 🚨 "The Forgotten Item" Horror Stories (TikTok/Reels Series)
+* **Campaign:** A short-form video series featuring people telling funny, disastrous stories about the worst thing they forgot on a trip (e.g., "I forgot my passport," "I forgot underwear for a 7-day trip").
+* **Call to Action:** "Never let this be you. Use Packwise."
+* **UGC (User Generated Content):** Ask followers to stitch or duet the video with their own forgotten item stories.
+
+### 🧳 The 10-Second Suitcase Animation
+* **Campaign:** Build an in-app feature that takes your checked-off packing list and generates a satisfying, 10-second stop-motion style animation of items flying into a suitcase.
+* **Call to Action:** Users will naturally want to post this satisfying content to TikTok or Instagram Reels before a trip, acting as free user-generated advertising.
+
+## 🎮 3. Gamification & Retention
+
+### 🏆 Packer Personalities & Badges
+* **What it is:** Assign users playful badges based on their behavior.
+  * *The Procrastinator:* Packs the night before.
+  * *The Overpacker:* Packs 30+ items for a weekend trip.
+  * *The Minimalist:* Under 15 items.
+* **Why it works:** People love identity-based features (e.g., MBTI, Astrology, Spotify Wrapped). They will screenshot and share their "Packer Personality" on Twitter/X and Instagram.
+
+### 🎁 Invite-to-Unlock (Referral Program)
+* **What it is:** Keep the core app free, but lock certain premium AI features (e.g., "AI Weather-Based Outfit Suggestions") or custom app themes behind a referral wall.
+* **Why it works:** "Invite 3 friends to unlock the Pro features for life" is a proven growth hack used by companies like Dropbox and Robinhood.
+
+## 📈 Summary Roadmap for Execution
+1. **Immediate (Low Effort, High Reward):** Implement a simple "Share List via Web Link" button to start capturing organic web traffic.
+2. **Next 30 Days:** Build Collaborative Lists to capture the "group trip" network effect.
+3. **Next 60 Days:** Launch the Instagram Story export feature with beautiful templates and "Packer Personalities".


### PR DESCRIPTION
Created a new markdown file `GROWTH_IDEAS.md` that acts as a playbook for driving user growth and network effects for Packwise. 

The ideas are broken down into three categories:
1.  **Core Viral Product Features:** Things like generating Instagram-optimized "Spotify Wrapped" style packing aesthetic cards, Collaborative Group Packing Lists, and Influencer Public Templates.
2.  **Social Media & Content Campaigns:** Ideas for TikTok/Reels such as the "Forgotten Item" Horror stories and the 10-Second Stop-Motion Suitcase Animation.
3.  **Gamification & Retention:** Proposing Packer Personalities badges (The Procrastinator, The Minimalist) and an Invite-to-Unlock referral program.

All changes are strictly documentation and have zero impact on the existing codebase. Tests were run to confirm no regressions.

---
*PR created automatically by Jules for task [12354473315512938288](https://jules.google.com/task/12354473315512938288) started by @mvng*