### PR TITLE
🔍 Scout: Fix inherited absolute OpenGraph URLs across nested routes

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-03-15 - [Absolute URLs in Next.js Root Layout OpenGraph]
+**Learning:** Hardcoding an absolute `openGraph.url` in the root `app/layout.tsx` of a Next.js App Router project forces all child routes to inherit it. This causes nested pages (like `/login` or `/claim/[token]`) to falsely share the homepage URL, breaking social sharing and SEO. Additionally, setting a relative `alternates.canonical` string on nested routes without defining `metadataBase` in the root layout leads to resolution errors.
+**Action:** Remove the absolute `url` from the root layout's OpenGraph object. Ensure `metadataBase` is configured at the root. Then, define route-specific relative strings (e.g., `alternates.canonical` and `openGraph.url`) on individual page/layout components so Next.js can resolve them dynamically and accurately.

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -3,7 +3,11 @@ import { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Sign In or Create Account | Packwise',
   description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
+  alternates: {
+    canonical: '/login',
+  },
   openGraph: {
+    url: '/login',
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   },

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -29,6 +29,8 @@ export async function generateMetadata({
       return {
         title: 'Shared Packing List | Packwise',
         description: 'Join this shared packing list on Packwise.',
+        alternates: { canonical: `/claim/${resolvedParams.token}` },
+        openGraph: { url: `/claim/${resolvedParams.token}` }
       }
     }
 
@@ -41,7 +43,9 @@ export async function generateMetadata({
     return {
       title,
       description,
+      alternates: { canonical: `/claim/${resolvedParams.token}` },
       openGraph: {
+        url: `/claim/${resolvedParams.token}`,
         title,
         description,
         type: 'website',
@@ -56,6 +60,8 @@ export async function generateMetadata({
     return {
       title: 'Shared Packing List | Packwise',
       description: 'Join this shared packing list on Packwise.',
+      alternates: { canonical: `/claim/${resolvedParams.token}` },
+      openGraph: { url: `/claim/${resolvedParams.token}` }
     }
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,6 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,19 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    url: '/',
+  },
+}
+
+
+
 export default async function HomePage() {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()

--- a/app/trip/[id]/layout.tsx
+++ b/app/trip/[id]/layout.tsx
@@ -18,6 +18,8 @@ export async function generateMetadata({
       return {
         title: 'Trip Not Found | Packwise',
         description: 'The packing list you are looking for could not be found.',
+        alternates: { canonical: `/trip/${resolvedParams.id}` },
+        openGraph: { url: `/trip/${resolvedParams.id}` }
       }
     }
 
@@ -30,7 +32,9 @@ export async function generateMetadata({
     return {
       title,
       description,
+      alternates: { canonical: `/trip/${resolvedParams.id}` },
       openGraph: {
+        url: `/trip/${resolvedParams.id}`,
         title,
         description,
         type: 'website',
@@ -45,6 +49,8 @@ export async function generateMetadata({
     return {
       title: 'Packwise – Smart Packing Lists',
       description: 'Create smart packing lists for every trip.',
+      alternates: { canonical: `/trip/${resolvedParams.id}` },
+      openGraph: { url: `/trip/${resolvedParams.id}` }
     }
   }
 }


### PR DESCRIPTION
💡 **What:** 
- Removed the hardcoded absolute `url` property from the `openGraph` object in the root `app/layout.tsx`.
- Explicitly defined relative `alternates.canonical` and `openGraph.url` values for the Homepage (`app/page.tsx`), Login page (`app/(auth)/login/layout.tsx`), dynamic Claim pages (`app/claim/[token]/page.tsx`), and dynamic Trip pages (`app/trip/[id]/layout.tsx`).

🎯 **Why:** 
Because Next.js App Router metadata inherits down the tree, hardcoding an absolute `openGraph.url` in the root layout caused all nested child routes to falsely broadcast the homepage URL. This broke social sharing cards and canonical linking for deeply nested and dynamic pages.

By leveraging the pre-existing `metadataBase` in the root layout, we can define relative URL paths on specific pages, allowing Next.js to correctly resolve the absolute URL per route.

📊 **Impact:** 
Resolves duplicate content signals sent to crawlers and ensures correct link unfurling across social media/messaging platforms for dynamic share pages (`/claim/...`).

🔬 **Verification:** 
- Tested with `pnpm lint && pnpm test` passing successfully.
- Code reviewed to ensure `metadataBase` supports relative path resolution.

🔗 **References:** 
[Next.js Metadata API - alternates](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#alternates)

---
*PR created automatically by Jules for task [2741563179082119797](https://jules.google.com/task/2741563179082119797) started by @mvng*