### PR TITLE
🎨 Palette: Add keyboard focus states for hover-revealed actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-05 - Fix Missing Focus States on Hover-Revealed Actions
+**Learning:** In Packwise, secondary actions like "Remove Item" or hover tooltips often utilize Tailwind's `opacity-0 group-hover:opacity-100` to keep the UI clean. However, this creates a severe accessibility issue for keyboard users, as the focused elements remain invisible (opacity 0) when tabbed to.
+**Action:** When implementing or refactoring UI components that hide elements using `group-hover:opacity-100`, always pair it with the corresponding focus utility classes. Use `focus:opacity-100`, `focus-visible:opacity-100`, or `group-focus-within:opacity-100` to ensure keyboard accessibility.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -865,7 +865,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         {itemCount > 0 && <span className="text-xs text-gray-500">({itemCount})</span>}
                         <button
                           onClick={() => handleRemoveLuggage(tl.id, tl.luggageId)}
-                          className="ml-1 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"
+                          className="ml-1 opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-400 hover:text-red-500 transition-opacity focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"
                           aria-label={`Remove ${tl.luggage.name}`}
                         ><X className="w-3.5 h-3.5" /></button>
                       </div>

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -67,7 +67,7 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
               {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}


### PR DESCRIPTION
💡 What: Added keyboard focus visibility to hover-revealed elements in `PackingListSection` and `TripMembersSection`.
🎯 Why: Hover-revealed elements utilizing `opacity-0 group-hover:opacity-100` are invisible to keyboard users. This patch adds the necessary focus utilities (`focus:opacity-100` and `group-focus-within:opacity-100`) to expose these interactive elements and tooltips when navigating via the `<Tab>` key.
📸 Before/After: Interactive elements like "Remove Luggage" and "Member Tooltip" were hidden when tabbed onto. They now correctly appear.
♿ Accessibility: Improved keyboard navigation and interactive element visibility for accessibility compliance.

---
*PR created automatically by Jules for task [5786127731001793050](https://jules.google.com/task/5786127731001793050) started by @mvng*