### PR TITLE
🔍 Scout: Fix inherited Open Graph URLs and canonicals

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,7 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+
+## 2024-06-06 - Inherited Open Graph URLs in Next.js App Router
+**Learning:** If you use relative URLs for metadata fields like `canonical` or `openGraph.url` (e.g., `url: '/'`) in Next.js App Router, you MUST define `metadataBase` in the root layout (e.g., `metadataBase: new URL('https://packwise-indol.vercel.app')`). Without it, Next.js will fall back to default localhost or deployment preview URLs, severely damaging SEO by indexing those alternative environments instead of production.
+**Action:** Always verify `metadataBase` is present in `app/layout.tsx` before implementing relative `canonical` or `openGraph.url` definitions in page layouts.

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -3,7 +3,11 @@ import { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Sign In or Create Account | Packwise',
   description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
+  alternates: {
+    canonical: '/login',
+  },
   openGraph: {
+    url: '/login',
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,6 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,17 @@
+import { Metadata } from 'next'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    url: '/',
+  },
+}
 
 export default async function HomePage() {
   const supabase = await createClient()


### PR DESCRIPTION
💡 **What:** Removed hardcoded absolute `openGraph.url` from root layout and defined relative canonicals/URLs in page-specific layouts.
🎯 **Why:** Hardcoding an absolute `openGraph.url` in the root `layout.tsx` forces all child routes to inherit it, breaking social sharing for nested pages.
📊 **Impact:** Ensures correct page-specific sharing URLs and prevents duplicate content penalties.
🔬 **Verification:** Evaluated via lint, test, and visual inspection of `<head>` during SSR.
🔗 **References:** Next.js Metadata API documentation.

---
*PR created automatically by Jules for task [2036334721690791812](https://jules.google.com/task/2036334721690791812) started by @mvng*