### PR TITLE
🎨 Palette: Add accessibility attributes and keyboard focus to icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Accessible Tooltips for Icon-Only Buttons
+**Learning:** Encountered icon-only buttons with tooltips (via `title` attribute) but missing explicit `aria-label`s for screen reader access. Found elements leveraging hover state reveal (`opacity-0 group-hover:opacity-100`) without addressing keyboard discoverability (missing `focus-within:opacity-100` on parent, or `focus-visible:opacity-100` on element).
+**Action:** When creating icon buttons, even with `title`, add `aria-label` for reliable screen reader interpretation. Always pair `group-hover` visibility classes with `focus-within` / `focus-visible` to guarantee keyboard accessibility.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -748,6 +748,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
             <button
               onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
               title="Add/Edit Note"
+              aria-label="Add or edit note"
               className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
             ><MessageSquare className="w-3.5 h-3.5" /></button>
             <button
@@ -758,7 +759,8 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                   ? 'bg-amber-100 text-amber-700 border-amber-300'
                   : 'bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600'
               }`}
-              aria-label={item.packLast ? 'Remove from pack last' : 'Mark as pack last'}
+              aria-label={item.packLast ? 'Remove from departure checklist' : 'Add to departure checklist (pack last)'}
+
             >
               <Sunrise className="w-3.5 h-3.5" />
             </button>
@@ -865,7 +867,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         {itemCount > 0 && <span className="text-xs text-gray-500">({itemCount})</span>}
                         <button
                           onClick={() => handleRemoveLuggage(tl.id, tl.luggageId)}
-                          className="ml-1 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"
+                          className="ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-gray-400 hover:text-red-500 transition-opacity focus:outline-none focus:ring-2 focus:ring-red-500 rounded px-1 flex items-center"
                           aria-label={`Remove ${tl.luggage.name}`}
                         ><X className="w-3.5 h-3.5" /></button>
                       </div>
@@ -1263,6 +1265,7 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                                   <button
                                     onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
                                     title="Add/Edit Note"
+                                    aria-label="Add or edit note"
                                     className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
                                   ><MessageSquare className="w-3.5 h-3.5" /></button>
                                   <button

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -110,15 +110,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Confirm"
+            aria-label="Confirm add member"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500"
             title="Cancel"
+            aria-label="Cancel add member"
           >
             <X className="w-3.5 h-3.5" />
           </button>

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -35,6 +35,7 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
+          aria-label={isDone ? 'Mark as incomplete' : 'Mark as complete'}
           className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
@@ -70,18 +71,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'} focus-within:opacity-100`}>
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:opacity-100"
             title="Edit task"
+            aria-label="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:opacity-100"
             title="Delete task"
+            aria-label="Delete task"
           >
             <Trash2 className="w-4 h-4" />
           </button>

--- a/components/TripPlanningAssistant/TaskForm.tsx
+++ b/components/TripPlanningAssistant/TaskForm.tsx
@@ -73,7 +73,8 @@ export default function TaskForm({ initialTask, onSave, onCancel, startDate }: T
         <button
           type="button"
           onClick={onCancel}
-          className="p-1 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors"
+          className="p-1 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          aria-label="Cancel"
         >
           <X className="w-5 h-5" />
         </button>


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes and keyboard focus states (`focus-visible` / `focus-within`) to multiple icon-only action buttons across the packing list, task assistant, and trip member sections.

### 🎯 Why
To improve keyboard accessibility and screen reader support. Previously, several hover-revealed action buttons lacked keyboard focus, making them undiscoverable without a mouse.

### 📸 Before/After
Before: Action buttons were only visible via `group-hover`.
After: Added `focus-within` and `focus-visible` along with `aria-label` for screen readers.

### ♿ Accessibility
- Added missing `aria-label` to icon-only buttons
- Added keyboard focus styles (`focus-visible:ring-2`)
- Ensured hover-only action groups are focusable via `focus-within:opacity-100`

---
*PR created automatically by Jules for task [11535648416408502835](https://jules.google.com/task/11535648416408502835) started by @mvng*