### PR TITLE
🔍 Scout: Fix OpenGraph URL inheritance and set canonical tags

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-03-16 - [OpenGraph URL Inheritance Anti-Pattern]
+**Learning:** In Next.js App Router, hardcoding an absolute `openGraph.url` or `alternates.canonical` in the root `app/layout.tsx` forces all child routes to inherit it. This breaks social sharing for nested pages, as they will falsely report the homepage as their URL.
+**Action:** Instead, set `metadataBase` in the root layout and define relative `alternates.canonical` and `openGraph.url` strings on individual routes (or dynamically in `generateMetadata` for dynamic routes).

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -1,9 +1,13 @@
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
+  alternates: {
+    canonical: '/login',
+  },
   title: 'Sign In or Create Account | Packwise',
   description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   openGraph: {
+    url: '/login',
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   },

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -41,7 +41,11 @@ export async function generateMetadata({
     return {
       title,
       description,
+      alternates: {
+        canonical: `/claim/${resolvedParams.token}`,
+      },
       openGraph: {
+        url: `/claim/${resolvedParams.token}`,
         title,
         description,
         type: 'website',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,6 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,17 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    url: '/',
+  },
+}
 
 export default async function HomePage() {
   const supabase = await createClient()

--- a/app/trip/[id]/layout.tsx
+++ b/app/trip/[id]/layout.tsx
@@ -30,7 +30,11 @@ export async function generateMetadata({
     return {
       title,
       description,
+      alternates: {
+        canonical: `/trip/${resolvedParams.id}`,
+      },
       openGraph: {
+        url: `/trip/${resolvedParams.id}`,
         title,
         description,
         type: 'website',


### PR DESCRIPTION
💡 **What:** Removed the hardcoded absolute `openGraph.url` from the root `app/layout.tsx` and instead explicitly defined relative `alternates.canonical` and `openGraph.url` properties on individual route levels (`/`, `/login`, `/claim/[token]`, `/trip/[id]`).

🎯 **Why:** In Next.js App Router, metadata is inherited down the route tree. Hardcoding an absolute URL (like the homepage URL) in the root layout caused all nested child pages to falsely report their canonical and Open Graph URLs as the homepage. This severely broke Open Graph link previews for shared trips and claim links, as social platforms would scrape the homepage instead of the intended dynamic content.

📊 **Impact:** Ensures search engines correctly identify the canonical source of each page, preventing duplicate content penalties. Crucially, it fixes social media link unfurling (Open Graph and Twitter Cards) for shared dynamic routes like `/claim/[token]`, directly improving shareability and click-through rates.

🔬 **Verification:** 
- The `openGraph.url` was verified to be removed from the root layout.
- The `alternates.canonical` and `openGraph.url` values were verified in the `generateMetadata` functions across target components.
- Run `pnpm lint` and `pnpm test` to ensure no regressions were introduced.

🔗 **References:** 
- Next.js Metadata Docs: https://nextjs.org/docs/app/building-your-application/optimizing/metadata
- Google Search Central Docs on Canonicalization: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls

---
*PR created automatically by Jules for task [9273042047294677979](https://jules.google.com/task/9273042047294677979) started by @mvng*