### PR TITLE
🎨 Palette: Enhance TripMembersSection accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Accessible interactive components in TripMembersSection
+**Learning:** Found that icon buttons used for adding, removing, confirming, and canceling in `TripMembersSection.tsx` lacked `aria-label`s, rendering them inaccessible to screen readers. Additionally, hover-triggered visual elements (like removing a user) and interactive focus states were missing proper `focus-visible` outlines and `group-focus-within` triggers for keyboard navigation.
+**Action:** When implementing icon-only buttons or hover-revealed features, always add explicit `aria-label` attributes and keyboard focus state utility classes (`focus-visible:ring-2`, `group-focus-within:block`) to ensure screen reader compatibility and keyboard operability.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                 isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={`${member.name}${isOwner ? ' (Click to remove)' : ''}`}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,8 +85,9 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 flex items-center justify-center transition-colors"
             title="Add member"
+            aria-label="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -110,15 +112,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors"
             title="Confirm"
+            aria-label="Confirm add member"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors"
             title="Cancel"
+            aria-label="Cancel add member"
           >
             <X className="w-3.5 h-3.5" />
           </button>


### PR DESCRIPTION
💡 What: Added aria-labels and keyboard focus states to icon buttons and tooltips in TripMembersSection.
🎯 Why: Improves keyboard accessibility and screen reader support for trip member management.
📸 Before/After: Visual changes are only to focus rings.
♿ Accessibility: Added missing aria-labels and focus states.

---
*PR created automatically by Jules for task [6840257183451798376](https://jules.google.com/task/6840257183451798376) started by @mvng*