### PR TITLE
🎨 Palette: [UX improvement] Improve keyboard accessibility in Trip Members section

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-18 - Keyboard Navigation in Non-Focusable Containers
+**Learning:** In Tailwind CSS, when hiding/showing child elements based on the focus state of a sibling interactive element (e.g., a button) inside a non-focusable parent container (`<div className="group">`), using `group-focus-within` (e.g., `group-focus-within:block`) is crucial for accessibility. Relying solely on hover states makes elements completely inaccessible to keyboard users.
+**Action:** When adding hover-revealed tooltips, actions, or buttons (like delete icons on a list item), always ensure keyboard focus triggers the same visibility using `group-focus-within` for the parent container and `focus-visible` for the interactive elements themselves.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -58,16 +58,17 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <div key={member.id} className="group relative">
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
-              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
-                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
+              className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${
+                isOwner ? 'hover:bg-red-100 hover:text-red-600 focus-visible:bg-red-100 focus-visible:text-red-600 cursor-pointer' : 'cursor-default'
               }`}
               title={member.name}
+              aria-label={isOwner ? `Remove ${member.name}` : member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,7 +85,8 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:border-transparent flex items-center justify-center transition-colors"
+            aria-label="Add member"
             title="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
@@ -110,14 +112,16 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 disabled:opacity-50 transition-colors"
+            aria-label="Confirm adding member"
             title="Confirm"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-1 rounded-lg transition-colors"
+            aria-label="Cancel adding member"
             title="Cancel"
           >
             <X className="w-3.5 h-3.5" />


### PR DESCRIPTION
## 💡 What
Added `focus-visible` and `group-focus-within` states to interactive elements in the `TripMembersSection` component. Added `aria-label` attributes to icon-only buttons.

## 🎯 Why
Tooltips and remove buttons were completely inaccessible to keyboard users because they relied entirely on hover states. The "Add member", "Confirm", and "Cancel" buttons also lacked visible focus indicators, making it hard to track keyboard position.

## 📸 Before/After
No visual changes for mouse users. Keyboard users will now see proper focus rings and can trigger tooltips and hidden action buttons via Tab navigation.

## ♿ Accessibility
- Added `focus-visible:ring` styles to all interactive elements.
- Replaced `group-hover` with `group-hover group-focus-within` for tooltips and remove buttons to ensure they appear on keyboard focus.
- Added `aria-label` to icon-only buttons for screen readers.

---
*PR created automatically by Jules for task [13910421324219346180](https://jules.google.com/task/13910421324219346180) started by @mvng*