### PR TITLE
🎨 Palette: Add Keyboard Focus Styles to Luggage Assignment

### DIFF
--- a/components/LuggageAssignmentButton.tsx
+++ b/components/LuggageAssignmentButton.tsx
@@ -77,7 +77,7 @@ export default function LuggageAssignmentButton({ currentLuggageId, tripLuggages
             e.stopPropagation()
             setIsOpen(true)
           }}
-          className="h-8 w-8 rounded-full hover:bg-gray-100 flex items-center justify-center text-lg transition-colors"
+          className="h-8 w-8 rounded-full hover:bg-gray-100 flex items-center justify-center text-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
           aria-label="Assign to luggage"
         >
           {currentIcon}
@@ -112,7 +112,7 @@ export default function LuggageAssignmentButton({ currentLuggageId, tripLuggages
                       <button
                         key={tl.id}
                         onClick={() => handleSelect(tl.id)}
-                        className={`w-full flex items-center gap-4 p-4 rounded-2xl border-2 transition-all ${
+                        className={`w-full flex items-center gap-4 p-4 rounded-2xl border-2 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
                           isSelected
                             ? 'border-blue-500 bg-blue-50'
                             : 'border-gray-200 hover:border-gray-300 bg-white'
@@ -138,7 +138,7 @@ export default function LuggageAssignmentButton({ currentLuggageId, tripLuggages
                   {/* No Bag Option */}
                   <button
                     onClick={() => handleSelect(null)}
-                    className={`w-full flex items-center gap-4 p-4 rounded-2xl border-2 transition-all ${
+                    className={`w-full flex items-center gap-4 p-4 rounded-2xl border-2 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
                       !currentLuggageId
                         ? 'border-blue-500 bg-blue-50'
                         : 'border-gray-200 hover:border-gray-300 bg-white'
@@ -161,7 +161,7 @@ export default function LuggageAssignmentButton({ currentLuggageId, tripLuggages
                 <div className="p-6 pt-0">
                   <button
                     onClick={() => setIsOpen(false)}
-                    className="w-full py-3 text-blue-600 font-semibold hover:bg-gray-50 rounded-xl transition-colors"
+                    className="w-full py-3 text-blue-600 font-semibold hover:bg-gray-50 rounded-xl transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
                   >
                     Cancel
                   </button>
@@ -183,7 +183,7 @@ export default function LuggageAssignmentButton({ currentLuggageId, tripLuggages
           e.stopPropagation()
           setIsOpen(!isOpen)
         }}
-        className="h-8 w-8 rounded-full hover:bg-gray-100 flex items-center justify-center text-lg transition-colors"
+        className="h-8 w-8 rounded-full hover:bg-gray-100 flex items-center justify-center text-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
         aria-label="Assign to luggage"
       >
         {currentIcon}
@@ -201,7 +201,7 @@ export default function LuggageAssignmentButton({ currentLuggageId, tripLuggages
               <button
                 key={tl.id}
                 onClick={() => handleSelect(tl.id)}
-                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors"
+                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
               >
                 <div className="text-2xl">{luggageIcons[tl.luggage.type as LuggageType]}</div>
                 <div className="flex-1 text-left">
@@ -226,7 +226,7 @@ export default function LuggageAssignmentButton({ currentLuggageId, tripLuggages
           {/* No Bag Option */}
           <button
             onClick={() => handleSelect(null)}
-            className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors"
+            className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500"
           >
             <div className="text-2xl">☐</div>
             <div className="flex-1 text-left">


### PR DESCRIPTION
💡 **What**: Added `focus-visible:ring-2` utility classes to all interactive elements within the `LuggageAssignmentButton` component (trigger button, popover items, mobile bottom sheet items, and cancel button).

🎯 **Why**: Previously, the luggage assignment dropdown and mobile bottom sheet lacked explicit keyboard focus indicators, making it difficult for keyboard-only users to navigate and select luggage options for their items. This change ensures clear visual feedback when tabbing through the interface.

📸 **Before/After**: See the attached screenshots in the CI/Verification steps.

♿ **Accessibility**: Improves WCAG 2.1 Focus Visible compliance by adding standard blue `focus-visible` rings to interactive elements, matching the app's existing design system.

---
*PR created automatically by Jules for task [6620820798632143085](https://jules.google.com/task/6620820798632143085) started by @mvng*