### PR TITLE
🔍 Scout: Add dynamic metadata to trip details page

### DIFF
--- a/app/trip/[id]/page.tsx
+++ b/app/trip/[id]/page.tsx
@@ -8,6 +8,59 @@ import TripWeather from '@/components/TripWeather'
 import TripWeatherSkeleton from '@/components/TripWeatherSkeleton'
 import TripPageClient from './TripPageClient'
 
+import type { Metadata } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Adding dynamic metadata to the trip page ensures that if a user decides to share
+// their trip URL, the Open Graph preview accurately reflects the trip destination
+// and context, significantly improving click-through rates.
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const resolvedParams = await params
+
+  try {
+    const tripResponse = await getSharedTripById(resolvedParams.id)
+    const trip = tripResponse?.trip
+
+    if (!trip) {
+      return {
+        title: 'Trip Details | Packwise',
+        description: 'View trip details and packing lists on Packwise.',
+      }
+    }
+
+    const titleName = trip.name || trip.destination || 'Untitled Trip'
+    const title = `${titleName} | Packwise Trip`
+    const description = trip.destination
+      ? `View the packing list and details for ${trip.destination} on Packwise.`
+      : `View trip details and packing lists on Packwise.`
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        type: 'website',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title,
+        description,
+      },
+    }
+  } catch (error) {
+    return {
+      title: 'Trip Details | Packwise',
+      description: 'View trip details and packing lists on Packwise.',
+    }
+  }
+}
+
+
 export default async function TripPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
 


### PR DESCRIPTION
💡 **What:** Added a dynamic `generateMetadata` function to the `app/trip/[id]/page.tsx` file.
🎯 **Why:** To ensure that when users share their trip URLs (e.g. via text, WhatsApp, or Slack), the Open Graph and Twitter Card previews accurately reflect the specific trip's destination and context, significantly improving click-through rates.
📊 **Impact:** Improves CTR on external-facing shared pages by replacing generic fallback text with contextually rich trip details.
🔬 **Verification:** Verified by inspecting the `app/trip/[id]/page.tsx` file to confirm correct `generateMetadata` implementation including a robust `try/catch` fallback block. `pnpm lint` and `pnpm test` executed successfully.
🔗 **References:** Next.js Metadata API Documentation and SCOUT guidelines.

---
*PR created automatically by Jules for task [3179230629354755595](https://jules.google.com/task/3179230629354755595) started by @mvng*