### PR TITLE
🎨 Palette: Improve icon button accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+
+## 2024-06-11 - Group Focus Within for Hidden Actions
+**Learning:** When using `group-hover:block` or `group-hover:hidden` on nested child elements within interactive parents (like an avatar pill that shows a remove button or tooltip on hover), keyboard-only users will not see these elements when focusing the parent button, causing accessibility issues.
+**Action:** Always pair `group-hover` visibility classes with `group-focus-within` equivalents (e.g., `group-focus-within:block` or `group-focus-within:opacity-100`) to ensure hidden child elements or tooltips are also revealed when their interactive parent receives keyboard focus.

--- a/components/TripMembersSection.tsx
+++ b/components/TripMembersSection.tsx
@@ -59,15 +59,15 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
             <button
               onClick={isOwner ? () => handleRemove(member.id) : undefined}
               className={`w-7 h-7 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-[10px] font-bold ring-2 ring-white transition-all ${
-                isOwner ? 'hover:bg-red-100 hover:text-red-600 cursor-pointer' : 'cursor-default'
+                isOwner ? 'hover:bg-red-100 hover:text-red-600 focus-visible:ring-blue-500 focus-visible:outline-none cursor-pointer' : 'cursor-default focus-visible:outline-none'
               }`}
               title={member.name}
             >
-              <span className="group-hover:hidden">{member.name.charAt(0).toUpperCase()}</span>
-              {isOwner && <X className="w-3 h-3 hidden group-hover:block" />}
+              <span className="group-hover:hidden group-focus-within:hidden">{member.name.charAt(0).toUpperCase()}</span>
+              {isOwner && <X className="w-3 h-3 hidden group-hover:block group-focus-within:block" />}
             </button>
             {/* Tooltip */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-20">
+            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-20">
               <div className="bg-gray-900 text-white text-[10px] font-medium px-2 py-1 rounded whitespace-nowrap">
                 {member.name}
                 {isOwner && <span className="text-gray-400 ml-1">&middot; click to remove</span>}
@@ -84,7 +84,8 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
         {isOwner && !isAdding && (
           <button
             onClick={() => setIsAdding(true)}
-            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors"
+            className="w-7 h-7 rounded-full border border-dashed border-gray-300 text-gray-400 hover:border-blue-400 hover:text-blue-500 flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            aria-label="Add member"
             title="Add member"
           >
             <Plus className="w-3.5 h-3.5" />
@@ -110,14 +111,16 @@ export default function TripMembersSection({ tripId, members: initialMembers, is
           <button
             onClick={handleAdd}
             disabled={isPending || !newName.trim()}
-            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            className="p-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
+            aria-label="Confirm member"
             title="Confirm"
           >
             <Check className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={() => { setIsAdding(false); setNewName(''); setError(null) }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-1"
+            aria-label="Cancel add member"
             title="Cancel"
           >
             <X className="w-3.5 h-3.5" />


### PR DESCRIPTION
### 💡 What
Added comprehensive keyboard accessibility and screen reader support to the `TripMembersSection` component's interactive elements.
- Injected `focus-visible:ring` states across all icon-only buttons for clear visual feedback during tab navigation.
- Added explicit `aria-label`s to the "Add member", "Confirm", and "Cancel" buttons.
- Leveraged `group-focus-within` on the member avatar pills to ensure the hover-revealed "remove" icon and member name tooltip are fully accessible to keyboard-only users.

### 🎯 Why
Icon-only buttons without `aria-label`s are opaque to screen readers, and hover-revealed actions inherently exclude users navigating via keyboard. These micro-improvements ensure the trip collaboration features are inclusive and seamless for all users, matching our high UX standards.

### 📸 Before/After
*(Verified visually via Playwright testing during implementation)*
**Before:** Tabbing to a member avatar pill showed no focus state, and the remove action/tooltip remained hidden. Add/Confirm buttons lacked labels for screen readers.
**After:** Clear blue/gray focus rings guide the user. Focusing a member pill now correctly surfaces the remove 'X' and tooltip just like a mouse hover does.

### ♿ Accessibility
- Fixed missing `aria-label`s on core interactive buttons.
- Addressed hover-exclusive interactive elements using `group-focus-within`.
- Implemented robust `focus-visible` styling for visible tab order tracking.

---
*PR created automatically by Jules for task [7599307986747181369](https://jules.google.com/task/7599307986747181369) started by @mvng*