### PR TITLE
🔧 Fix: redirect to forked trip after login

### DIFF
--- a/.jules/felix.md
+++ b/.jules/felix.md
@@ -1,0 +1,3 @@
+## 2026-06-12 - SessionStorage and Next.js Auth Callbacks
+**Learning:** In Next.js App Router, using a server route (`app/auth/callback/route.ts`) for authentication means it cannot directly access client-side APIs like `sessionStorage`. Features that rely on client-stored intent (like pending actions saved before login) must either be checked entirely in client components *after* the redirect from the server callback, or be stored in a cookie instead of `sessionStorage`.
+**Action:** When saving an action state pre-login to execute post-login, implement the execution logic directly in the authentication client component (like `app/(auth)/login/page.tsx`) immediately after a successful client login, instead of expecting the server to handle it.

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,8 +1,12 @@
+
 'use client'
 
 import { useState } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
+import { forkTrip } from '@/actions/trip.actions'
+import { getTripLocalStorageState } from '@/components/PackingListSection'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -11,6 +15,28 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [message, setMessage] = useState<string | null>(null)
+  const router = useRouter()
+
+  const handleLoginSuccess = async () => {
+    const tripIdToFork = sessionStorage.getItem('fork_trip_after_login')
+    if (tripIdToFork) {
+      sessionStorage.removeItem('fork_trip_after_login')
+      try {
+        const localStorageState = getTripLocalStorageState(tripIdToFork)
+        const result = await forkTrip(tripIdToFork, localStorageState)
+        if (result.success && result.tripId) {
+          if (typeof window !== 'undefined' && localStorageState) {
+            localStorage.removeItem(`packwise_trip_${tripIdToFork}`)
+          }
+          router.push(`/trip/${result.tripId}`)
+          return
+        }
+      } catch (err) {
+        console.error('Failed to fork trip after login:', err)
+      }
+    }
+    window.location.href = '/dashboard' // Intentionally using window.location for full app reload / hydration on auth change just to be safe
+  }
 
   const handleAuth = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -36,7 +62,7 @@ export default function LoginPage() {
       // If email confirmation is disabled, signUp returns a valid session.
       // Redirect immediately to dashboard (the auth callback will upsert the Prisma User).
       if (data?.session) {
-        window.location.href = '/dashboard'
+        handleLoginSuccess()
         return
       }
 
@@ -49,7 +75,7 @@ export default function LoginPage() {
         setLoading(false)
         return
       }
-      window.location.href = '/dashboard'
+      handleLoginSuccess()
       return
     }
     setLoading(false)


### PR DESCRIPTION
🐛 **Issue:** Closes #50 (Trip sharing fork workflow).
🔍 **Root Cause:** When an unauthenticated user clicks to copy a shared trip, the trip ID is stored in \`sessionStorage\`. However, the login page unconditionally redirected to \`/dashboard\` after a successful login without checking this intended post-login action.
🛠️ **Fix:** Added a \`handleLoginSuccess\` callback in \`app/(auth)/login/page.tsx\` that checks \`sessionStorage\` for \`fork_trip_after_login\`. If present, it calls the \`forkTrip\` Server Action (passing any locally saved state) and redirects directly to the newly copied trip instead of the dashboard. Also ensures \`localStorage\` is cleared upon successful fork.
✅ **Verification:** Verified that \`pnpm lint\` passes and tests are executing correctly.
⚠️ **Notes:** None.

---
*PR created automatically by Jules for task [3262238530249586574](https://jules.google.com/task/3262238530249586574) started by @mvng*