### PR TITLE
⚡ Bolt: Remove N+1 query in day-plan sync

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+## 2024-05-24 - Prisma N+1 Query in Loop
+**Learning:** The `sync` route was making a `findMany` query for `packingItem` inside a loop for each category, despite the fact that `category.items` were already loaded via the `include: { items: true }` directive in the initial `category` query. This resulted in an N+1 query pattern.
+**Action:** Avoid querying the database inside a loop when the related items are already included in the parent query. Sort or process the included items in memory instead.

--- a/app/api/day-plans/sync/route.ts
+++ b/app/api/day-plans/sync/route.ts
@@ -50,10 +50,7 @@ export async function POST(req: Request) {
         })
       }
 
-      const existingItems = await prisma.packingItem.findMany({
-        where: { categoryId: category.id },
-        orderBy: { order: 'desc' },
-      })
+      const existingItems = [...category.items].sort((a, b) => b.order - a.order)
       let maxItemOrder = existingItems.reduce((max, i) => Math.max(max, i.order), -1)
 
       for (const item of items) {


### PR DESCRIPTION
💡 What: Removed a redundant `prisma.packingItem.findMany` query inside a loop and instead used the already included `category.items` sorted in-memory.
🎯 Why: It solves an N+1 query performance bottleneck where an additional database roundtrip was made for each category during day-plan synchronization.
📊 Impact: Reduces database queries from O(n) to O(1) during sync, significantly improving latency when syncing large day plans.
🔬 Measurement: Verify by executing the `/api/day-plans/sync` endpoint and observing reduced database query counts or improved response times.

---
*PR created automatically by Jules for task [8932473746034721892](https://jules.google.com/task/8932473746034721892) started by @mvng*