### PR TITLE
🔍 Scout: Add dynamic metadata to trip details page

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-10-27 - [Dynamic Metadata for Shared Trip Pages]
+**Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/trip/[id]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR when users share their individual trips via messaging platforms.
+**Action:** Always check public-facing pages (like share or trip pages) for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback and database query to ensure robust SSR and accurate social sharing previews.

--- a/app/trip/[id]/page.tsx
+++ b/app/trip/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
 import { getSharedTripById } from '@/actions/trip.actions'
 import { getTripWeather } from '@/actions/weather.actions'
 import { createClient } from '@/lib/supabase/server'
@@ -7,6 +8,59 @@ import { Suspense } from 'react'
 import TripWeather from '@/components/TripWeather'
 import TripWeatherSkeleton from '@/components/TripWeatherSkeleton'
 import TripPageClient from './TripPageClient'
+
+
+// SCOUT SEO RATIONALE:
+// Adding dynamic metadata to the individual trip page ensures that when users share their trip link
+// via social media or messaging apps, the Open Graph preview accurately reflects
+// the trip destination and context, significantly improving click-through rates.
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const resolvedParams = await params
+
+  try {
+    const trip = await prisma.trip.findUnique({
+      where: { id: resolvedParams.id },
+      select: { name: true, destination: true },
+    })
+
+    if (!trip) {
+      return {
+        title: 'Trip Details | Packwise',
+        description: 'View trip details and packing lists on Packwise.',
+      }
+    }
+
+    const titleName = trip.name || trip.destination || 'Untitled Trip'
+    const title = `${titleName} | Packwise`
+    const description = trip.destination
+      ? `View the trip details and packing lists for ${trip.destination} on Packwise.`
+      : `View trip details and packing lists on Packwise.`
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        type: 'website',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title,
+        description,
+      },
+    }
+  } catch (error) {
+    return {
+      title: 'Trip Details | Packwise',
+      description: 'View trip details and packing lists on Packwise.',
+    }
+  }
+}
 
 export default async function TripPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params


### PR DESCRIPTION
💡 **What:** Added a `generateMetadata` function to `app/trip/[id]/page.tsx` to dynamically fetch the trip's destination and name to populate Open Graph and Twitter card meta tags.

🎯 **Why:** When users share their trip page link via social media or messaging platforms (e.g. iMessage, WhatsApp), the unfurled preview card will now show the specific trip details rather than a generic site description, improving clarity and click-through rate.

📊 **Impact:** Expected to significantly improve user engagement and CTR for shared trip links due to accurate, context-aware social sharing previews.

🔬 **Verification:** Confirmed the code passes all linters and tests. You can verify by sharing a trip URL on a platform that parses Open Graph data, or by using a tool like the Twitter Card Validator or Facebook Sharing Debugger.

🔗 **References:** [Next.js Metadata Object and generateMetadata API](https://nextjs.org/docs/app/api-reference/functions/generate-metadata)

---
*PR created automatically by Jules for task [14526946074578546018](https://jules.google.com/task/14526946074578546018) started by @mvng*