### PR TITLE
🎨 Palette: Add accessibility to Trip Planning Task Cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Fix missing accessibility on hover-revealed action buttons
+**Learning:** Found a pattern where secondary task actions (like Edit/Delete) were hidden by default and only revealed on hover using React state. The action buttons lacked `aria-label` attributes (causing poor screen reader context), and because visibility depended on pointer events, keyboard-only users could not navigate to them or tell when they were focused.
+**Action:** When creating hover-revealed action areas, prefer CSS `group-hover` combined with `group-focus-within` on the parent to ensure visibility triggers for keyboard users. Always add explicit `focus-visible` styling and descriptive `aria-label` attributes to the action buttons inside.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,23 +20,21 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
+          aria-label={isDone ? `Mark "${task.title}" as pending` : `Mark "${task.title}" as done`}
         >
           {isDone ? <CheckCircle className="w-5 h-5" /> : <Circle className="w-5 h-5" />}
         </button>
@@ -70,18 +67,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 transition-opacity opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
+            aria-label={`Edit task "${task.title}"`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
+            aria-label={`Delete task "${task.title}"`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
### 💡 What
Replaced React `useState` hover tracking on `TaskCard` action buttons with Tailwind CSS `group-hover` and `group-focus-within`, and added focus styling and descriptive `aria-label` attributes to all task action buttons.

### 🎯 Why
Previously, the Edit and Delete buttons were completely hidden from keyboard users because their visibility relied on pointer events (`onMouseEnter`). They also lacked `aria-label`s, meaning screen readers couldn't decipher what task the edit/delete buttons applied to.

### 📸 Before/After
Before: The action buttons only appeared when hovered with a mouse and could not be focused via the `Tab` key.
After: The action buttons now appear either when the user hovers the task OR when they navigate into the task container using the `Tab` key, and they show clear `focus-visible` outline rings.

### ♿ Accessibility
- Ensured keyboard users can access and trigger hidden secondary actions.
- Ensured screen reader users receive full context when focusing icon-only buttons via `aria-label`s.

---
*PR created automatically by Jules for task [17433112808300613729](https://jules.google.com/task/17433112808300613729) started by @mvng*