### PR TITLE
⚡ Bolt: Eliminate redundant N+1 query in day plan sync

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2024-06-14 - Prisma Relation Unloading Trap
+**Learning:** When attempting to eliminate Prisma N+1 queries by replacing `findMany` calls with direct property access (e.g., `category.items`), explicitly verify that the parent query actually utilizes the `include` directive for that relation. In Prisma, accessing an unloaded relation returns `undefined`, which can cause silent functional regressions if default fallbacks like `|| []` are incorrectly assumed to accurately reflect the database state.
+**Action:** Always check the parent query's `include` or `select` block to confirm a relation is eagerly loaded before refactoring child queries to use in-memory property access.

--- a/app/api/day-plans/sync/route.ts
+++ b/app/api/day-plans/sync/route.ts
@@ -50,10 +50,7 @@ export async function POST(req: Request) {
         })
       }
 
-      const existingItems = await prisma.packingItem.findMany({
-        where: { categoryId: category.id },
-        orderBy: { order: 'desc' },
-      })
+      const existingItems = category.items || []
       let maxItemOrder = existingItems.reduce((max, i) => Math.max(max, i.order), -1)
 
       for (const item of items) {


### PR DESCRIPTION
💡 What: Replaced a redundant N+1 Prisma query inside a loop with an in-memory property access (`category.items`).
🎯 Why: The `category` variable already includes the related `items` because the earlier `existingCategories` query uses `include: { items: true }`. Calling `findMany` again for each category inside the loop was unnecessary and caused performance degradation.
📊 Impact: Prevents N+1 database explosions when syncing multiple categories, dramatically speeding up DB execution time.
🔬 Measurement: Verify day plan synchronization completes successfully and observe reduced database queries in Prisma logs.

---
*PR created automatically by Jules for task [14189258040045246931](https://jules.google.com/task/14189258040045246931) started by @mvng*