### PR TITLE
🔍 Scout: [Dynamic Metadata for Trip Pages]

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2026-03-15 - [Dedicated Queries for Dynamic Metadata]
+**Learning:** When generating dynamic metadata in Next.js Server Components, it is often more performant to perform a focused, lightweight database query (`prisma.model.findUnique` with a minimal `select` for only the fields needed, like `name` and `destination`) rather than reusing the page's primary data-fetching action (e.g., `getSharedTripById`), which may load deeply nested relationships unnecessary for SEO tags.
+**Action:** Always favor isolated, precise database queries within `generateMetadata` functions to avoid pulling massive object graphs into memory solely to extract a page title.

--- a/app/trip/[id]/page.tsx
+++ b/app/trip/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
 import { getSharedTripById } from '@/actions/trip.actions'
 import { getTripWeather } from '@/actions/weather.actions'
 import { createClient } from '@/lib/supabase/server'
@@ -7,6 +8,59 @@ import { Suspense } from 'react'
 import TripWeather from '@/components/TripWeather'
 import TripWeatherSkeleton from '@/components/TripWeatherSkeleton'
 import TripPageClient from './TripPageClient'
+
+
+// SCOUT SEO RATIONALE:
+// Adding dynamic metadata to the trip page ensures that when users share this link
+// via social media or messaging apps, the Open Graph preview accurately reflects
+// the trip destination and context, significantly improving click-through rates.
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const resolvedParams = await params
+
+  try {
+    const trip = await prisma.trip.findUnique({
+      where: { id: resolvedParams.id },
+      select: { name: true, destination: true },
+    })
+
+    if (!trip) {
+      return {
+        title: 'Trip Details | Packwise',
+        description: 'View trip details and packing list on Packwise.',
+      }
+    }
+
+    const titleName = trip.name || trip.destination || 'Untitled Trip'
+    const title = `${titleName} | Packwise Trip`
+    const description = trip.destination
+      ? `View the packing list and details for the trip to ${trip.destination} on Packwise.`
+      : `View trip details and packing list on Packwise.`
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        type: 'website',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title,
+        description,
+      },
+    }
+  } catch (error) {
+    return {
+      title: 'Trip Details | Packwise',
+      description: 'View trip details and packing list on Packwise.',
+    }
+  }
+}
 
 export default async function TripPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params


### PR DESCRIPTION
💡 **What:** Added `generateMetadata` to the trip detail page to dynamically generate Open Graph and Twitter card tags based on the trip's destination.
🎯 **Why:** To ensure that when users share this link via social media or messaging apps, the Open Graph preview accurately reflects the trip destination and context, significantly improving click-through rates.
📊 **Impact:** Improves unfurl previews and click-through rates on messaging platforms when users share their trip pages.
🔬 **Verification:** Verify with `pnpm test`.
🔗 **References:** Next.js Metadata API docs.

---
*PR created automatically by Jules for task [18024589122021899648](https://jules.google.com/task/18024589122021899648) started by @mvng*