### PR TITLE
🎨 Palette: Add accessible roles and focus states to laundry toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-14 - Use correct ARIA attributes and focus for custom switch roles
+**Learning:** Found custom toggle components (e.g., `LaundryToggle`) implementing a switch using a `<button>` element but missing the required `role="switch"` and using the incorrect `aria-pressed` attribute instead of `aria-checked`. The toggle also lacked explicit keyboard focus indicators (`focus-visible:ring-2`), making it inaccessible for keyboard users to know when it was focused.
+**Action:** When implementing a custom toggle switch using a button, always ensure it has `role="switch"`, uses `aria-checked` to reflect its state (compliant with `jsx-a11y`), includes a descriptive `aria-label`, and incorporates visible focus styles like `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2`.

--- a/components/EditTripModal.tsx
+++ b/components/EditTripModal.tsx
@@ -307,10 +307,12 @@ export default function EditTripModal({ trip, onClose, onSuccess }: EditTripModa
               <button
                 type="button"
                 onClick={() => handleLaundryToggle(!hasLaundry)}
-                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none ${
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
                   hasLaundry ? 'bg-blue-600' : 'bg-gray-200'
                 }`}
-                aria-pressed={hasLaundry}
+                role="switch"
+                aria-checked={hasLaundry}
+                aria-label="Toggle laundry access"
               >
                 <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
                   hasLaundry ? 'translate-x-6' : 'translate-x-1'

--- a/components/LaundryToggle.tsx
+++ b/components/LaundryToggle.tsx
@@ -40,10 +40,12 @@ export default function LaundryToggle({ startDate, endDate, onChange }: LaundryT
         </div>
         <button
           onClick={() => handleToggle(!hasLaundry)}
-          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none ${
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
             hasLaundry ? 'bg-blue-600' : 'bg-gray-200'
           }`}
-          aria-pressed={hasLaundry}
+          role="switch"
+          aria-checked={hasLaundry}
+          aria-label="Toggle laundry access"
         >
           <span
             className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${


### PR DESCRIPTION
💡 What: Added `role="switch"`, `aria-checked` (replaced `aria-pressed`), `aria-label`, and keyboard focus styling (`focus-visible:ring-2`) to the Laundry Toggle buttons.
🎯 Why: To improve screen reader semantics and ensure keyboard users can clearly see when the toggle is focused, compliant with the project's accessibility rules.
📸 Before/After: N/A (Focus styles added, primarily screen reader improvements, but focus ring is now visible).
♿ Accessibility: Ensures compliance with WCAG guidelines for custom switch controls and the project's strict `jsx-a11y` ESLint rules.

---
*PR created automatically by Jules for task [617123178527151207](https://jules.google.com/task/617123178527151207) started by @mvng*