### PR TITLE
🎨 Palette: Fix toggle switch accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-15 - Fixing aria-pressed on elements with role="switch"
+**Learning:** Elements functioning as switches and styled similarly using Tailwind must use `role="switch"` and `aria-checked` to be semantically correct. Using `aria-pressed` without `role="switch"` can result in the component being perceived incorrectly by screen readers, and is contrary to the strict `jsx-a11y` ESLint rules in Next.js. Also, `focus-visible` must be set explicitly.
+**Action:** When creating or modifying a custom toggle/switch component, always set `role="switch"` and replace `aria-pressed` with `aria-checked`.

--- a/components/EditTripModal.tsx
+++ b/components/EditTripModal.tsx
@@ -307,10 +307,11 @@ export default function EditTripModal({ trip, onClose, onSuccess }: EditTripModa
               <button
                 type="button"
                 onClick={() => handleLaundryToggle(!hasLaundry)}
-                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none ${
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
                   hasLaundry ? 'bg-blue-600' : 'bg-gray-200'
                 }`}
-                aria-pressed={hasLaundry}
+                role="switch"
+                aria-checked={hasLaundry}
               >
                 <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
                   hasLaundry ? 'translate-x-6' : 'translate-x-1'

--- a/components/LaundryToggle.tsx
+++ b/components/LaundryToggle.tsx
@@ -40,10 +40,11 @@ export default function LaundryToggle({ startDate, endDate, onChange }: LaundryT
         </div>
         <button
           onClick={() => handleToggle(!hasLaundry)}
-          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none ${
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
             hasLaundry ? 'bg-blue-600' : 'bg-gray-200'
           }`}
-          aria-pressed={hasLaundry}
+          role="switch"
+          aria-checked={hasLaundry}
         >
           <span
             className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${


### PR DESCRIPTION
## 💡 What\nReplaced `aria-pressed` with `role="switch"` and `aria-checked` on laundry toggle switches, and added explicit `focus-visible` styling.\n\n## 🎯 Why\nTo improve semantic correctness and ensure keyboard navigation visibility for accessibility.\n\n## 📸 Before/After\nN/A (Invisible change mostly, added focus ring).\n\n## ♿ Accessibility\nAddresses missing `role="switch"` when toggles use check states and explicitly adds visible focus indicators for keyboard navigation.

---
*PR created automatically by Jules for task [5285854981222114622](https://jules.google.com/task/5285854981222114622) started by @mvng*