### PR TITLE
🎨 Palette: Add role=switch to laundry toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-17 - Use role="switch" for toggle buttons
+**Learning:** Found custom UI toggle buttons using `aria-pressed` without the proper `role="switch"`. While `aria-pressed` is valid for toggle buttons, the Next.js `jsx-a11y` rules strictly enforce that elements functioning as semantic switches must use `role="switch"` and `aria-checked` instead, to provide the best screen reader context.
+**Action:** Always implement custom UI toggle switches with `role="switch"` and `aria-checked` instead of `aria-pressed` to ensure strict compliance and better screen reader context.

--- a/components/EditTripModal.tsx
+++ b/components/EditTripModal.tsx
@@ -310,7 +310,8 @@ export default function EditTripModal({ trip, onClose, onSuccess }: EditTripModa
                 className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none ${
                   hasLaundry ? 'bg-blue-600' : 'bg-gray-200'
                 }`}
-                aria-pressed={hasLaundry}
+                role="switch"
+                aria-checked={hasLaundry}
               >
                 <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
                   hasLaundry ? 'translate-x-6' : 'translate-x-1'

--- a/components/LaundryToggle.tsx
+++ b/components/LaundryToggle.tsx
@@ -43,7 +43,8 @@ export default function LaundryToggle({ startDate, endDate, onChange }: LaundryT
           className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none ${
             hasLaundry ? 'bg-blue-600' : 'bg-gray-200'
           }`}
-          aria-pressed={hasLaundry}
+          role="switch"
+          aria-checked={hasLaundry}
         >
           <span
             className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${


### PR DESCRIPTION
💡 What: Replaced aria-pressed with role=switch and aria-checked on laundry toggle buttons.

🎯 Why: To properly announce these custom toggles as 'switch' elements to screen readers, complying with strict jsx-a11y rules for Next.js and significantly improving the accessibility of the on/off states.

📸 Before/After: N/A (Non-visual screen reader improvement)

♿ Accessibility: Added role='switch' and changed aria-pressed to aria-checked to align with WAI-ARIA standards for switch controls.

---
*PR created automatically by Jules for task [16870585069460502160](https://jules.google.com/task/16870585069460502160) started by @mvng*