### PR TITLE
⚡ Bolt: Optimize packing progress query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2024-05-18 - Replacing Deep Include Count Queries with Aggregates
+**Learning:** In Prisma with Postgres, using \`include: { items: true }\` just to count the quantities or items creates massive memory bloat by loading thousands of relational rows into Node.js (a Cartesian product explosion over the network).
+**Action:** Always replace deeply nested \`include\` queries intended solely for counts or sums with parallel \`prisma.model.groupBy()\` (with \`_sum: { quantity: true }\`) or \`prisma.model.count()\` queries to shift the aggregation math back to the database engine.

--- a/app/api/trips/[id]/progress/route.ts
+++ b/app/api/trips/[id]/progress/route.ts
@@ -28,16 +28,17 @@ export async function GET(
       return NextResponse.json({ error: 'Trip not found' }, { status: 404 })
     }
 
-    const categories = await prisma.category.findMany({
-      where: {
-        packingList: {
-          tripId: id
-        }
-      },
-      include: {
-        items: true
-      }
-    })
+        const [categories, itemsAgg] = await Promise.all([
+      prisma.category.findMany({
+        where: { packingList: { tripId: id } },
+        select: { id: true, name: true }
+      }),
+      prisma.packingItem.groupBy({
+        by: ['categoryId', 'isPacked'],
+        where: { category: { packingList: { tripId: id } } },
+        _sum: { quantity: true }
+      })
+    ])
 
     let total = 0
     let packed = 0
@@ -47,10 +48,13 @@ export async function GET(
       let catTotal = 0
       let catPacked = 0
 
-      category.items.forEach(item => {
-        catTotal += item.quantity
-        if (item.isPacked) {
-          catPacked += item.quantity
+      itemsAgg.forEach(agg => {
+        if (agg.categoryId === category.id) {
+          const qty = agg._sum.quantity || 0
+          catTotal += qty
+          if (agg.isPacked) {
+            catPacked += qty
+          }
         }
       })
 


### PR DESCRIPTION
💡 What: Flattened deeply nested Prisma Cartesian product query into parallel \`category.findMany\` and \`packingItem.groupBy\` aggregations.
🎯 Why: Resolves severe memory and payload bloat. The old code loaded every single item into Node.js memory just to tally sums, causing OOMs on large lists.
📊 Impact: Shifts aggregation to the database layer, drastically reducing network I/O and server memory allocation.
🔬 Measurement: Verify /api/trips/[id]/progress still correctly returns category totals without causing N+1 DB explosions.

---
*PR created automatically by Jules for task [1331427350364217108](https://jules.google.com/task/1331427350364217108) started by @mvng*