### PR TITLE
🎨 Palette: Improve accessibility and keyboard navigation on TaskCard

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-06-19 - Replaced JS hover state with CSS group-focus-within
+**Learning:** JS `onMouseEnter`/`onMouseLeave` hover states make interactive elements inaccessible to keyboard users because they cannot be focused when hidden.
+**Action:** Replace React `useState` hover tracking with Tailwind CSS `group`, `group-hover:opacity-100`, and `group-focus-within:opacity-100` so elements become visible naturally upon hover or keyboard focus within the container.
+
 ## 2024-05-24 - Add accessible close buttons to modals
 **Learning:** Found a pattern across multiple modal components (`EditTripModal`, `LuggagePickerModal`, `InventoryPickerModal`) where icon-only close buttons lacked `aria-label`s and the modals lacked `Escape` key close handlers.
 **Action:** When creating or editing modals in the future, ensure that icon-only buttons have descriptive `aria-label`s and that keyboard accessibility (like the Escape key) is implemented to close the modals.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,21 +20,20 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? `Mark "${task.title}" as incomplete` : `Mark "${task.title}" as complete`}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,17 +68,19 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 transition-opacity opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            aria-label={`Edit task "${task.title}"`}
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            aria-label={`Delete task "${task.title}"`}
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
           >
             <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
💡 What: Replaced JS-based hover state with CSS (`group-focus-within`) for better keyboard navigation. Added screen-reader-friendly ARIA labels and `focus-visible` indicators.

🎯 Why: Hidden actions (edit/delete) were completely unreachable for keyboard users and lacked context for screen readers.

📸 Before/After: Visuals unchanged for mouse users, but interaction is now robust for keyboard users.

♿ Accessibility: Actions now appear via `group-focus-within`. Screen readers now read out context for icon-only buttons.

---
*PR created automatically by Jules for task [5538488843323229992](https://jules.google.com/task/5538488843323229992) started by @mvng*