### PR TITLE
🔍 Scout: Add dynamic metadata to trip pages

### DIFF
--- a/app/trip/[id]/page.tsx
+++ b/app/trip/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { getSharedTripById } from '@/actions/trip.actions'
 import { getTripWeather } from '@/actions/weather.actions'
@@ -7,6 +8,59 @@ import { Suspense } from 'react'
 import TripWeather from '@/components/TripWeather'
 import TripWeatherSkeleton from '@/components/TripWeatherSkeleton'
 import TripPageClient from './TripPageClient'
+
+
+// SCOUT SEO RATIONALE:
+// Adding dynamic metadata to the trip page ensures that when users share this link
+// the Open Graph preview accurately reflects the trip destination and name,
+// significantly improving click-through rates.
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+
+  try {
+    const trip = await prisma.trip.findUnique({
+      where: { id },
+      select: { name: true, destination: true },
+    })
+
+    if (!trip) {
+      return {
+        title: 'Trip Details | Packwise',
+        description: 'View trip details and packing lists on Packwise.',
+      }
+    }
+
+    const titleName = trip.name || trip.destination || 'Untitled Trip'
+    const title = `${titleName} | Packwise`
+    const description = trip.destination
+      ? `View the trip details and packing lists for ${trip.destination}.`
+      : `View this trip on Packwise. Track packing lists, luggage, and day plans!`
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        type: 'website',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title,
+        description,
+      },
+    }
+  } catch (error) {
+    return {
+      title: 'Trip Details | Packwise',
+      description: 'View trip details and packing lists on Packwise.',
+    }
+  }
+}
 
 export default async function TripPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,5 @@
+💡 **What:** Added `generateMetadata` to dynamic trip pages to populate title and Open Graph metadata.
+🎯 **Why:** To improve click-through rates and unfurl previews when trip links are shared.
+📊 **Impact:** Enhances SEO and social sharing metrics for public trips.
+🔬 **Verification:** Check page source in a browser or use social sharing debuggers.
+🔗 **References:** Next.js Metadata Docs


### PR DESCRIPTION
💡 **What:** Added `generateMetadata` to dynamic trip pages to populate title and Open Graph metadata. 
🎯 **Why:** To improve click-through rates and unfurl previews when trip links are shared. 
📊 **Impact:** Enhances SEO and social sharing metrics for public trips. 
🔬 **Verification:** Check page source in a browser or use social sharing debuggers. 
🔗 **References:** Next.js Metadata Docs

---
*PR created automatically by Jules for task [12123504938031684988](https://jules.google.com/task/12123504938031684988) started by @mvng*