### PR TITLE
⚡ Bolt: Optimize trip packing progress DB queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+## 2024-10-25 - Prisma groupBy Relation Limitations
+**Learning:** Prisma's `groupBy` aggregation does not support relation filtering in its `where` clause (e.g., you cannot filter `packingItem` by `category: { packingList: { tripId: id } }`). Attempting to do so will result in a runtime `PrismaClientValidationError`.
+**Action:** When pushing deep relational aggregations down to the database using `groupBy`, you must split the operation into two sequential queries: first fetch the relevant IDs using a standard `findMany` relation query, then pass those IDs into the `groupBy`'s `where` clause using an `in` filter.

--- a/app/api/trips/[id]/progress/route.ts
+++ b/app/api/trips/[id]/progress/route.ts
@@ -28,40 +28,58 @@ export async function GET(
       return NextResponse.json({ error: 'Trip not found' }, { status: 404 })
     }
 
+    // ⚡ Bolt Performance Optimization
+    // Why: Replaced deeply nested Cartesian product query with two flat queries using `groupBy` and `_sum`.
+    // Impact: Avoids loading entire item objects into memory just to calculate counts, reducing DB latency and Node.js memory footprint.
+
+    // First query: Get categories to map IDs to names and determine order
     const categories = await prisma.category.findMany({
-      where: {
-        packingList: {
-          tripId: id
-        }
-      },
-      include: {
-        items: true
-      }
+      where: { packingList: { tripId: id } },
+      select: { id: true, name: true, order: true },
+      orderBy: { order: 'asc' }
     })
+
+    const categoryIds = categories.map(c => c.id)
+
+    // Second query: Get aggregated stats for only those categories
+    // (Prisma groupBy does not support relation filters, so we use the categoryIds array)
+    const itemStats = categoryIds.length > 0 ? await prisma.packingItem.groupBy({
+      by: ['categoryId', 'isPacked'],
+      where: { categoryId: { in: categoryIds } },
+      _sum: { quantity: true }
+    }) : []
 
     let total = 0
     let packed = 0
     const byCategory: { name: string, total: number, packed: number }[] = []
 
-    categories.forEach(category => {
-      let catTotal = 0
-      let catPacked = 0
+    // Initialize category tracking map
+    const categoryMap = new Map(categories.map(c => [
+      c.id,
+      { name: c.name, total: 0, packed: 0 }
+    ]))
 
-      category.items.forEach(item => {
-        catTotal += item.quantity
-        if (item.isPacked) {
-          catPacked += item.quantity
-        }
-      })
+    // Apply stats from grouping
+    for (const stat of itemStats) {
+      const cat = categoryMap.get(stat.categoryId)
+      if (!cat) continue
 
-      total += catTotal
-      packed += catPacked
+      const qty = stat._sum.quantity || 0
+      cat.total += qty
+      total += qty
 
-      byCategory.push({
-        name: category.name,
-        total: catTotal,
-        packed: catPacked
-      })
+      if (stat.isPacked) {
+        cat.packed += qty
+        packed += qty
+      }
+    }
+
+    // Preserve original category order
+    categories.forEach(c => {
+      const stats = categoryMap.get(c.id)
+      if (stats) {
+        byCategory.push(stats)
+      }
     })
 
     const percentage = total === 0 ? 0 : Math.round((packed / total) * 100)


### PR DESCRIPTION
💡 What: Replaced a deeply nested Cartesian product Prisma query (`include: { items: true }`) with two lightweight queries using `prisma.packingItem.groupBy` and `_sum`.

🎯 Why: The original query fetched every single item object for a trip into Node.js memory simply to count quantities and calculate packing progress, leading to an N+1 data explosion, high memory overhead, and increased DB latency on large trips.

📊 Impact: Significantly reduces serialized DB payload size and Node.js memory footprint. Avoids loading full objects when only aggregate counts are needed.

🔬 Measurement: Verified using `pnpm test` and `pnpm lint`. All tests passed. Check the Network tab in browser when loading a trip page; the `/api/trips/[id]/progress` endpoint will return significantly faster for large trips.

---
*PR created automatically by Jules for task [15487578050373668302](https://jules.google.com/task/15487578050373668302) started by @mvng*