### PR TITLE
🎨 Palette: Improve accessibility and keyboard navigation for TaskCard actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-20 - Accessible Hover Actions in Lists
+**Learning:** Hiding secondary list actions (edit, delete) using `opacity-0` and JS-based hover states breaks keyboard accessibility because the elements never become visible when focused, and parent containers cannot inherently capture `focus`.
+**Action:** When creating hover-to-reveal actions in lists, use Tailwind CSS pure utility classes instead of React state: wrap the row in a `group`, use `group-hover:opacity-100` for mouse users, and crucially add `group-focus-within:opacity-100` to reveal the actions when a keyboard user tabs into any interactive child. Always pair with `focus-visible:ring-2` on the buttons themselves for clear indication.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,21 +20,20 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? "Mark as undone" : "Mark as done"}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 focus-visible:ring-2 focus-visible:outline-none rounded-full transition-colors ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,18 +68,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 focus-visible:ring-2 focus-visible:outline-none rounded-md hover:bg-blue-50 transition-colors"
             title="Edit task"
+            aria-label="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 focus-visible:ring-2 focus-visible:outline-none rounded-md hover:bg-red-50 transition-colors"
             title="Delete task"
+            aria-label="Delete task"
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
💡 What: Replaced state-based hover with Tailwind `group-hover`, added `group-focus-within` for keyboard accessibility, and added missing `aria-label`s for icon buttons.
🎯 Why: Action buttons were invisible to keyboard-only users because they were hidden behind an `opacity-0` that only toggled on mouse enter. They also lacked labels for screen readers.
📸 Before/After: Visuals remain the same on mouse hover, but buttons are now visible on keyboard focus and announced correctly to screen readers.
♿ Accessibility: Added `group-focus-within:opacity-100` to reveal hidden actions on tab focus. Added descriptive `aria-label`s for Edit, Delete, and toggle status icon-only buttons.

---
*PR created automatically by Jules for task [1116745281010303835](https://jules.google.com/task/1116745281010303835) started by @mvng*