### PR TITLE
🔍 Scout: Add ItemList structured data to shared trips

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,10 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-03-14 - [Next.js App Router Root Canonical URLs]
+**Learning:** Do not define a static canonical URL (e.g., `alternates: { canonical: '/' }`) in the root `app/layout.tsx`. Doing so causes Next.js to merge and pass this static canonical URL to all child pages, incorrectly instructing search engines to treat every page as a duplicate of the homepage.
+**Action:** When implementing canonical URLs, define them explicitly on a per-page basis or use a dynamically generated layout that relies on the request URL.
+
+## 2024-03-14 - [JSON-LD Stored XSS Prevention]
+**Learning:** When injecting JSON-LD structured data via `<script dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />`, any user-supplied content within the JSON (like trip names or item names) can break out of the script tag if it contains a `</script>` string, leading to severe Stored XSS vulnerabilities.
+**Action:** Always safely escape JSON strings before injecting them into the DOM, e.g., by replacing less-than signs: `JSON.stringify(data).replace(/</g, '\\u003c')`.

--- a/app/trip/[id]/page.tsx
+++ b/app/trip/[id]/page.tsx
@@ -55,13 +55,34 @@ export default async function TripPage({ params }: { params: Promise<{ id: strin
     )
   }
 
+
+  // SCOUT SEO RATIONALE:
+  // Adding an ItemList structured data schema to the public trip page helps search engines
+  // understand the contents of the packing list, making it eligible for rich results.
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    itemListElement: fetchedTrip.packingLists?.[0]?.categories?.flatMap((category: any, catIndex: number) =>
+      category.items?.map((item: any, itemIndex: number) => ({
+        '@type': 'ListItem',
+        position: catIndex * 100 + itemIndex + 1,
+        name: item.name,
+      })) || []
+    ) || [],
+    name: fetchedTrip.name || fetchedTrip.destination || 'Packing List',
+    description: `Packing list for ${fetchedTrip.destination || 'your trip'}`,
+  }
+
   return (
-    <TripPageClient
-      initialTrip={fetchedTrip}
-      user={user}
-      isOwner={isOwner}
-      initialTripTimezone={tripTimezone}
-      weatherComponent={weatherComponent}
-    />
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }} />
+      <TripPageClient
+        initialTrip={fetchedTrip}
+        user={user}
+        isOwner={isOwner}
+        initialTripTimezone={tripTimezone}
+        weatherComponent={weatherComponent}
+      />
+    </>
   )
 }


### PR DESCRIPTION
💡 **What:** Added JSON-LD `ItemList` structured data to the public shared trip page (`app/trip/[id]/page.tsx`).
🎯 **Why:** To help search engines understand the contents and structure of the packing lists. This makes the shared trip page eligible for rich results in search engines.
📊 **Impact:** Increases the likelihood of the page being displayed as a rich snippet (e.g. displaying list items directly in search results), improving visibility and potential click-through rate.
🔬 **Verification:** The structured data implementation was verified via automated testing to ensure it avoids N+1 access errors by correctly targeting `fetchedTrip.packingLists?.[0]?.categories`. The output was properly sanitized using `replace(/</g, '\\u003c')` to prevent Cross-Site Scripting (XSS) vulnerabilities.
🔗 **References:** https://developers.google.com/search/docs/appearance/structured-data/carousel

---
*PR created automatically by Jules for task [3010614210786645592](https://jules.google.com/task/3010614210786645592) started by @mvng*