### PR TITLE
🎨 Palette: Add accessibility attributes to calendar sync dropdown

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-21 - Add accessible states to custom dropdown toggles
+**Learning:** Found that custom dropdowns (like `CalendarSyncDropdown`) often miss `aria-expanded` and `aria-haspopup` attributes, leaving screen reader users unaware of the menu's state or purpose.
+**Action:** Always include `aria-expanded={isOpen}` and `aria-haspopup="menu"` (or "true") on buttons that toggle custom dropdown menus.

--- a/components/CalendarSyncDropdown.tsx
+++ b/components/CalendarSyncDropdown.tsx
@@ -27,6 +27,8 @@ export default function CalendarSyncDropdown({ tripId }: CalendarSyncDropdownPro
       <button
         onClick={() => setShowCalendarMenu(!showCalendarMenu)}
         className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all"
+        aria-expanded={showCalendarMenu}
+        aria-haspopup="menu"
         title="Calendar Sync"
       >
         <span>📅</span>


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-haspopup="menu"` to the CalendarSyncDropdown button.
🎯 Why: Custom dropdowns often miss accessible states, leaving screen reader users unaware of the menu's state or purpose.
♿ Accessibility: Improved keyboard and screen reader accessibility by announcing the element as a menu toggle and indicating its current open/closed state.

---
*PR created automatically by Jules for task [1577832970909076865](https://jules.google.com/task/1577832970909076865) started by @mvng*