### PR TITLE
🔧 Fix: redirect to forked trip after login

### DIFF
--- a/.jules/felix.md
+++ b/.jules/felix.md
@@ -1,0 +1,3 @@
+## 2026-06-23 - [Fix: redirect to forked trip after login]
+**Learning:** Next.js auth logic needs to correctly check sessionStorage for intended redirects before generically routing to `/dashboard`.
+**Action:** Always verify local/session storage intent handlers when modifying auth flows.

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
+import { forkTrip } from '@/actions/trip.actions'
+import { getTripLocalStorageState } from '@/components/PackingListSection'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -11,6 +13,29 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [message, setMessage] = useState<string | null>(null)
+
+  const handleLoginSuccess = async () => {
+    const forkTripId = sessionStorage.getItem('fork_trip_after_login')
+    if (forkTripId) {
+      try {
+        const localStorageState = getTripLocalStorageState(forkTripId)
+        const result = await forkTrip(forkTripId, localStorageState)
+
+        sessionStorage.removeItem('fork_trip_after_login')
+        if (typeof window !== 'undefined' && localStorageState) {
+          localStorage.removeItem(`packwise_trip_${forkTripId}`)
+        }
+
+        if (result.success && result.tripId) {
+          window.location.href = `/trip/${result.tripId}`
+          return
+        }
+      } catch (err) {
+        console.error('Failed to fork trip after login:', err)
+      }
+    }
+    window.location.href = '/dashboard'
+  }
 
   const handleAuth = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -36,7 +61,7 @@ export default function LoginPage() {
       // If email confirmation is disabled, signUp returns a valid session.
       // Redirect immediately to dashboard (the auth callback will upsert the Prisma User).
       if (data?.session) {
-        window.location.href = '/dashboard'
+        await handleLoginSuccess()
         return
       }
 
@@ -49,7 +74,7 @@ export default function LoginPage() {
         setLoading(false)
         return
       }
-      window.location.href = '/dashboard'
+      await handleLoginSuccess()
       return
     }
     setLoading(false)


### PR DESCRIPTION
🐛 **Issue:** Closes #499 (Night 26 - Trip sharing: post-login fork workflow).
🔍 **Root Cause:** When an unauthenticated user tried to fork a shared trip, they were correctly redirected to login with their intent stored in `sessionStorage`. However, the login page's `handleAuth` function ignored this intent and unconditionally redirected them to `/dashboard` upon a successful login or signup.
🛠️ **Fix:** Implemented a `handleLoginSuccess` callback in `app/(auth)/login/page.tsx`. This callback explicitly checks `sessionStorage` for the `fork_trip_after_login` key. If present, it executes the `forkTrip` Server Action (restoring any local state), clears the session and local storage, and then redirects the user directly to their new forked trip page. If the key is absent or the fork operation fails, it gracefully falls back to the `/dashboard` redirect.
✅ **Verification:** Verified via `pnpm lint` and `pnpm test`. 
⚠️ **Notes:** Since the Next.js router sometimes caches aggressively during auth state transitions, the fix intentionally utilizes `window.location.href` to enforce a full-page reload and ensure the new auth cookie is properly picked up by the server on the subsequent request.

---
*PR created automatically by Jules for task [12864386113050931043](https://jules.google.com/task/12864386113050931043) started by @mvng*