### PR TITLE
🔍 Scout: Add canonical URLs to public pages

### DIFF
--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -7,6 +7,12 @@ export const metadata: Metadata = {
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   },
+  // SCOUT SEO RATIONALE:
+  // Adding a canonical URL directly to the login page prevents duplicate indexing if the page
+  // is accessed via varying query parameters (e.g., ?error=unauthorized).
+  alternates: {
+    canonical: 'https://packwise-indol.vercel.app/login',
+  },
 }
 
 export default function LoginLayout({

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
 
+
 export default function LoginPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -51,11 +51,22 @@ export async function generateMetadata({
         title,
         description,
       },
+      // SCOUT SEO RATIONALE:
+      // Shared claim pages are private by nature and should not be indexed by search engines.
+      // Adding a robots directive prevents sensitive user data from leaking into public search results.
+      robots: {
+        index: false,
+        follow: false,
+      },
     }
   } catch (error) {
     return {
       title: 'Shared Packing List | Packwise',
       description: 'Join this shared packing list on Packwise.',
+      robots: {
+        index: false,
+        follow: false,
+      },
     }
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,16 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 
+export const metadata = {
+  // SCOUT SEO RATIONALE:
+  // Defining a page-specific canonical URL ensures that if tracking parameters are added
+  // to the root URL (e.g., /?ref=twitter), search engines consolidate link equity and
+  // avoid duplicate content penalties.
+  alternates: {
+    canonical: 'https://packwise-indol.vercel.app',
+  },
+};
+
 export default async function HomePage() {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()


### PR DESCRIPTION
💡 **What:** 
- Added a canonical URL (`https://packwise-indol.vercel.app`) to `app/page.tsx`
- Added a canonical URL (`https://packwise-indol.vercel.app/login`) to `app/(auth)/login/layout.tsx`
- Added `robots: { index: false, follow: false }` directive to `app/claim/[token]/page.tsx`

🎯 **Why:** 
- Canonical URLs on the root and login pages ensure that if these pages are accessed via URLs containing query parameters (like UTM tags for tracking, e.g. `/?ref=twitter`), search engines consolidate the link equity into the main clean URL instead of indexing multiple duplicate versions of the same content.
- The shared claim page represents private user data and one-time invitation links. These should explicitly not be indexed by search engines to maintain privacy and a high-quality crawl scope. 

📊 **Impact:** 
- Prevents duplicate content penalties, consolidates link equity for core public pages, and protects sensitive user data on shared link pages.

🔬 **Verification:** 
- Verified `alternates.canonical` renders in `<head>` for `/` and `/login`.
- Verified `<meta name="robots" content="noindex, nofollow">` renders in `<head>` for `/claim/[token]`.

🔗 **References:** 
- [Google Search Central: Consolidate duplicate URLs](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)
- [Next.js Metadata Object](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadata-object)

---
*PR created automatically by Jules for task [1358629455760107153](https://jules.google.com/task/1358629455760107153) started by @mvng*