### PR TITLE
🎨 Palette: Add accessible focus states and ARIA labels to hover-revealed inventory action buttons

### DIFF
--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -118,7 +118,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +139,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What: Added explicit `aria-label`s and `focus-visible:ring-2` with `focus:opacity-100` utility classes to the Edit and Delete action buttons within the `CategorySection` component's inventory item lists.
🎯 Why: These actions were previously only visible on mouse hover (`group-hover:opacity-100`) and lacked descriptive labels, making them invisible to keyboard-only users tabbing through the list, and unintuitive for screen readers traversing the DOM since they only contained a generic `<svg>` tag. Adding these labels and visual indicators ensures the buttons are both fully discoverable via keyboard focus and clearly announced by assistive tech.
📸 Before/After: Verified via local screenshot test; focus rings now correctly appear and make the buttons opaque when tabbed to.
♿ Accessibility: Improves keyboard nav (`focus-visible`) and screen reader support (`aria-label`) for dynamic list item actions.

---
*PR created automatically by Jules for task [8799520680843749210](https://jules.google.com/task/8799520680843749210) started by @mvng*