### PR TITLE
🎨 Palette: Accessible TaskCard buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+
+## 2024-06-24 - Add accessible labels to TaskCard icon buttons
+**Learning:** Hover-revealed icon buttons consistently lack ARIA labels and focus states, making them inaccessible to screen reader and keyboard users.
+**Action:** Always add context-specific `aria-label`s and `focus-visible` utility classes (including `focus-within:opacity-100` for parent containers) to ensure hidden actions are discoverable and usable.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -35,7 +35,8 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? `Mark "${task.title}" as incomplete` : `Mark "${task.title}" as complete`}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full transition-colors ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,18 +71,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className={`flex items-center gap-1 transition-opacity focus-within:opacity-100 ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md hover:bg-blue-50 transition-colors"
             title="Edit task"
+            aria-label={`Edit "${task.title}"`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-md hover:bg-red-50 transition-colors"
             title="Delete task"
+            aria-label={`Delete "${task.title}"`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
💡 What: Added accessible `aria-label`s and `focus-visible` utility classes to the icon-only action buttons in the `TaskCard` component. Added `focus-within:opacity-100` to the parent container.
🎯 Why: Hover-revealed icon-only buttons are inaccessible to screen reader users (no context) and keyboard users (hidden until hovered, lack focus indicators). These changes make the actions discoverable and usable for all users.
📸 Before/After: Visual changes are limited to showing the buttons when keyboard-focused and displaying a focus ring.
♿ Accessibility: Improves screen reader context via descriptive labels and ensures full keyboard navigation support.

---
*PR created automatically by Jules for task [15173592270171143751](https://jules.google.com/task/15173592270171143751) started by @mvng*