### PR TITLE
🎨 Palette: Add keyboard accessibility to dashboard action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Fix hover-revealed action button accessibility in Dashboard
+**Learning:** Found a recurring accessibility issue pattern specific to this app's components where hover-revealed action containers (`group-hover:opacity-100`) omit `focus-within:opacity-100`, making child buttons completely invisible to keyboard-only users navigating via Tab.
+**Action:** Always include `focus-within:opacity-100` on containers of hover-revealed elements and ensure child buttons have explicit `focus-visible` ring utilities and context-specific `aria-label`s.

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -157,19 +157,19 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 flex gap-1 transition-opacity">
+      <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-1 transition-opacity">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all flex items-center justify-center"
-          aria-label="Edit trip"
+          className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-lg transition-all flex items-center justify-center"
+          aria-label={`Edit ${trip.name || trip.destination || 'trip'}`}
         >
           <Edit2 className="w-4 h-4" />
         </button>
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center"
-          aria-label="Delete trip"
+          className="p-1.5 text-gray-500 hover:text-red-500 hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center"
+          aria-label={`Delete ${trip.name || trip.destination || 'trip'}`}
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
         </button>
@@ -200,19 +200,19 @@ export default function DashboardClient({
       </Link>
 
       {/* Action buttons */}
-      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
+      <div className="absolute top-1/2 -translate-y-1/2 right-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 flex gap-0.5 transition-opacity bg-white/90 rounded-md backdrop-blur-sm shadow-sm">
         <button
           onClick={(e) => handleEditTrip(e, trip)}
-          className="p-1.5 text-gray-500 hover:text-blue-600 rounded transition-all flex items-center justify-center"
-          aria-label="Edit trip"
+          className="p-1.5 text-gray-500 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded transition-all flex items-center justify-center"
+          aria-label={`Edit ${trip.name || trip.destination || 'trip'}`}
         >
           <Edit2 className="w-4 h-4" />
         </button>
         <button
           onClick={(e) => handleDeleteTrip(e, trip.id)}
           disabled={deletingId === trip.id}
-          className="p-1.5 text-gray-500 hover:text-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center"
-          aria-label="Delete trip"
+          className="p-1.5 text-gray-500 hover:text-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded transition-all disabled:opacity-50 flex items-center justify-center"
+          aria-label={`Delete ${trip.name || trip.destination || 'trip'}`}
         >
           {deletingId === trip.id ? <MoreHorizontal className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
         </button>


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the hover-revealed edit and delete buttons on the dashboard trip cards. Included `focus-within:opacity-100` to the container so it becomes visible when focused via keyboard. Added explicit `focus-visible` styles with a ring, and improved `aria-label` context to include the specific trip name.

🎯 Why: Previously, these actions were strictly visible only on mouse hover (`group-hover:opacity-100`), making them completely invisible to users navigating the application with a keyboard.

♿ Accessibility: Ensures that keyboard-only users and screen readers can easily discover, identify, and use these actions.

---
*PR created automatically by Jules for task [5073975531584791702](https://jules.google.com/task/5073975531584791702) started by @mvng*