### PR TITLE
🔍 Scout: Add page-specific canonical URLs to public pages

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-06-25 - [Page-Specific Canonical URLs]
+**Learning:** Defining static canonical URLs in the root `layout.tsx` causes all child pages to inherit the homepage's canonical URL, leading to duplicate content issues. Page-specific canonicals must be defined in the `page.tsx` metadata (or the route's `layout.tsx` if the page is a client component).
+**Action:** Always define `alternates: { canonical: ... }` at the leaf level or explicitly per route, and never as a static value in the root layout.

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -3,6 +3,12 @@ import { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Sign In or Create Account | Packwise',
   description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
+  // SCOUT SEO RATIONALE:
+  // Explicitly defining the canonical URL for the login page prevents search engines
+  // from indexing URL variations with query parameters as separate duplicate pages.
+  alternates: {
+    canonical: '/login',
+  },
   openGraph: {
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,17 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+import { Metadata } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Defining the canonical URL here rather than in the root layout prevents Next.js
+// from incorrectly inheriting this static canonical to all dynamic child routes,
+// avoiding duplicate content issues across the site.
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+}
 
 export default async function HomePage() {
   const supabase = await createClient()


### PR DESCRIPTION
💡 **What:** Added explicit `alternates: { canonical: '/' }` to `app/page.tsx` and `alternates: { canonical: '/login' }` to `app/(auth)/login/layout.tsx` metadata.
🎯 **Why:** To prevent search engines from incorrectly indexing URL variations (e.g., with tracking query parameters) as duplicate content, and properly setting canonicals at the leaf level to avoid improper inheritance from a root layout.
📊 **Impact:** Ensures indexation of only the primary URLs (`/` and `/login`), concentrating link equity and mitigating duplicate content penalties.
🔬 **Verification:** `pnpm lint` and `pnpm test` pass. Metadata properly exports `alternates.canonical` which Next.js successfully resolves relative to the `metadataBase`.
🔗 **References:** [Next.js Metadata API](https://nextjs.org/docs/app/building-your-application/optimizing/metadata)

---
*PR created automatically by Jules for task [17008144309462712448](https://jules.google.com/task/17008144309462712448) started by @mvng*