### PR TITLE
🔍 Scout: Add Canonical URLs to Public Routes

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-03-16 - [Next.js App Router Canonical Tags]
+**Learning:** In Next.js App Router, defining a static canonical URL (e.g., `alternates: { canonical: '/' }`) in the root `app/layout.tsx` is an anti-pattern because Next.js merges and passes this static canonical URL to all child pages, incorrectly instructing search engines to treat every page as a duplicate of the homepage.
+**Action:** Always define page-specific canonicals directly in the leaf `page.tsx` file's `metadata` or `generateMetadata` function to ensure correct self-canonicalization.

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -41,6 +41,9 @@ export async function generateMetadata({
     return {
       title,
       description,
+      alternates: {
+        canonical: `/claim/${resolvedParams.token}`,
+      },
       openGraph: {
         title,
         description,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,15 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+}
+
+
 export default async function HomePage() {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()


### PR DESCRIPTION
💡 **What:** Added `alternates: { canonical: ... }` to the Next.js `metadata` object in `app/page.tsx` and the `generateMetadata` function in `app/claim/[token]/page.tsx`.
🎯 **Why:** To prevent duplicate content issues by explicitly telling search engines the preferred URL for a given page. Static canonical tags in the root layout are an anti-pattern in Next.js App Router as they inherit to all child routes, so they must be applied at the page level.
📊 **Impact:** Improves SEO hygiene, ensures proper indexing, and prevents "Duplicate without user-selected canonical" errors in Google Search Console.
🔬 **Verification:** `pnpm lint` and `pnpm test` pass. Verified the `metadata` object additions.
🔗 **References:** Next.js Metadata API Documentation, Google Search Central docs on Canonicalization.

---
*PR created automatically by Jules for task [17974447349677311544](https://jules.google.com/task/17974447349677311544) started by @mvng*