### PR TITLE
🎨 Palette: Add accessible labels and focus states to inventory category items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-26 - Add accessible labels and focus states to inventory items
+**Learning:** Found that icon-only buttons for favorite, edit, and delete in the inventory CategorySection were missing explicit aria-labels that include the item's context (e.g., `Edit ${item.name}`). Additionally, these hover-revealed action buttons lacked focus-visible styling to make them usable by keyboard-only users.
+**Action:** Always ensure hover-revealed action buttons have descriptive aria-label attributes that include item context, and explicit focus-visible utility classes (e.g., `focus-visible:opacity-100`) so they are discoverable and triggerable by screen reader and keyboard users.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -89,7 +89,8 @@ export default function CategorySection({
                 onClick={() => onToggleFavorite(item)}
                 disabled={isPending}
                 title={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50"
+                aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`}
+                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
               >
                 {item.isFavorite ? (
                   '⭐'
@@ -118,7 +119,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +140,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What: Added explicit `aria-label`s to the icon-only favorite, edit, and delete buttons within the `CategorySection` component.
🎯 Why: These buttons previously lacked descriptive context (making them inaccessible to screen readers) and lacked keyboard focus indicators (making them undiscoverable/unusable for keyboard-only users).
📸 Before/After: Visual changes include a blue/red ring around the action buttons when navigating via keyboard `Tab`.
♿ Accessibility: Ensures that interactive hover actions are fully compliant with WCAG keyboard accessibility and screen reader standards.

---
*PR created automatically by Jules for task [3248376663083300893](https://jules.google.com/task/3248376663083300893) started by @mvng*