### PR TITLE
🎨 Palette: Make hover-revealed action buttons keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+
+## 2024-06-27 - [Hover-revealed action buttons lack accessibility]
+**Learning:** Hover-revealed icon buttons across components consistently miss ARIA labels and explicit focus states, making them undiscoverable for screen reader and keyboard users.
+**Action:** Always provide context-specific `aria-label` attributes (e.g., `aria-label="Edit ${item.name}"`) and explicit `focus-visible` classes (e.g., `focus-visible:opacity-100`) for all hover-revealed actions.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -89,7 +89,8 @@ export default function CategorySection({
                 onClick={() => onToggleFavorite(item)}
                 disabled={isPending}
                 title={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50"
+                aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`}
+                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm"
               >
                 {item.isFavorite ? (
                   '⭐'
@@ -118,7 +119,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:opacity-100"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +140,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300 focus-visible:opacity-100"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What: Added context-specific `aria-label` attributes and explicit `focus-visible` styling (`focus-visible:ring-2`) to the favorite, edit, and delete icon buttons within the `CategorySection` component.
🎯 Why: Hover-revealed action buttons were previously relying on pointer events (`group-hover:opacity-100`) for visibility and lacked context, making them undiscoverable for keyboard navigators and unclear for screen reader users.
📸 Before/After: Visual changes provided via Playwright screenshot verifying explicit focus rings on tab navigation.
♿ Accessibility: Ensures WCAG compliance for focus indicators and provides dynamic, descriptive names (e.g. `Edit Passport`) for assistive technologies.

---
*PR created automatically by Jules for task [15239394074076433955](https://jules.google.com/task/15239394074076433955) started by @mvng*