### PR TITLE
⚡ Bolt: Optimize packing progress query

### DIFF
--- a/app/api/trips/[id]/progress/route.ts
+++ b/app/api/trips/[id]/progress/route.ts
@@ -28,29 +28,59 @@ export async function GET(
       return NextResponse.json({ error: 'Trip not found' }, { status: 404 })
     }
 
-    const categories = await prisma.category.findMany({
-      where: {
-        packingList: {
-          tripId: id
+    // ⚡ Bolt Optimization: Offload item aggregation to the database using groupBy
+    // instead of pulling all full item object trees into application memory.
+    const [categories, itemStats] = await Promise.all([
+      prisma.category.findMany({
+        where: {
+          packingList: {
+            tripId: id
+          }
+        },
+        select: {
+          id: true,
+          name: true
         }
-      },
-      include: {
-        items: true
-      }
-    })
+      }),
+      prisma.packingItem.groupBy({
+        by: ['categoryId', 'isPacked'],
+        where: {
+          category: {
+            packingList: {
+              tripId: id
+            }
+          }
+        },
+        _sum: {
+          quantity: true
+        }
+      })
+    ])
 
     let total = 0
     let packed = 0
     const byCategory: { name: string, total: number, packed: number }[] = []
 
+    // ⚡ Bolt Optimization: Group the stats by categoryId for O(1) lookup
+    const statsByCategory = itemStats.reduce((acc, stat) => {
+      if (!acc[stat.categoryId]) {
+        acc[stat.categoryId] = []
+      }
+      acc[stat.categoryId].push(stat)
+      return acc
+    }, {} as Record<string, typeof itemStats>)
+
     categories.forEach(category => {
+      const catStats = statsByCategory[category.id] || []
+
       let catTotal = 0
       let catPacked = 0
 
-      category.items.forEach(item => {
-        catTotal += item.quantity
-        if (item.isPacked) {
-          catPacked += item.quantity
+      catStats.forEach(stat => {
+        const qty = stat._sum.quantity || 0
+        catTotal += qty
+        if (stat.isPacked) {
+          catPacked += qty
         }
       })
 


### PR DESCRIPTION
💡 What: Replaced prisma.category.findMany({ include: { items: true } }) with parallel prisma.category.findMany({ select: { id: true, name: true } }) and prisma.packingItem.groupBy() queries, and utilized an O(1) Map lookup.
🎯 Why: Fetching all packing items into application memory just to calculate totals creates unnecessary database overhead and memory bloat.
📊 Impact: Eliminates massive Cartesian product data explosion, significantly reducing database load and application memory footprint.
🔬 Measurement: Verify /api/trips/[id]/progress returns correctly calculated percentages and check database logs for query efficiency.

---
*PR created automatically by Jules for task [10341629410945223722](https://jules.google.com/task/10341629410945223722) started by @mvng*