### PR TITLE
🎨 Palette: Make TaskCard actions keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-27 - Make hover-revealed React state UI elements keyboard accessible
+**Learning:** Found an accessibility issue pattern where hover-revealed action buttons controlled by a React state (`isHovered`) toggling `opacity-100` and `opacity-0` classes were invisible to keyboard-only users who navigate via the `Tab` key, since `onMouseEnter` is not triggered.
+**Action:** Always ensure that dynamically revealed elements based on hover state also utilize `focus-within:opacity-100` on the container, along with explicit `focus-visible:ring-2` and descriptive `aria-label`s on the buttons themselves to ensure screen reader and keyboard users can discover and trigger them.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -70,18 +70,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className={`flex items-center gap-1 transition-opacity focus-within:opacity-100 ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors"
             title="Edit task"
+            aria-label={`Edit task ${task.title}`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 transition-colors"
             title="Delete task"
+            aria-label={`Delete task ${task.title}`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
💡 What:
Added `focus-within:opacity-100` to the hover-revealed action container in `TaskCard`. Added `aria-label`s and `focus-visible` ring styles to the edit and delete buttons.

🎯 Why:
The edit and delete buttons were previously hidden behind an `isHovered` state that only triggered on mouse hover, making them invisible to keyboard-only users who navigate via the Tab key.

📸 Before/After:
Before: Actions only visible on mouse hover, screen reader receives no context.
After: Actions visible on mouse hover AND keyboard focus. Screen reader announces "Edit task [Title]" and "Delete task [Title]".

♿ Accessibility:
- Added `focus-within` visibility for keyboard navigation
- Added `focus-visible` focus rings
- Added descriptive `aria-label`s instead of generic titles

---
*PR created automatically by Jules for task [16773756071748027522](https://jules.google.com/task/16773756071748027522) started by @mvng*