### PR TITLE
🎨 Palette: Enhance accessibility of inventory category lists

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-28 - Add accessible labels to interactive icons in inventory
+**Learning:** Discovered an accessibility issue pattern in inventory lists where interactive icon-only buttons (like favorite toggles) and overflow menus ("•••") lack context-specific `aria-label`s and proper focus indicators, making them difficult for screen reader and keyboard users to navigate.
+**Action:** Always ensure stateful toggles and generic menus include interpolated `aria-label`s specifying the target item, and apply `focus-visible:ring-2` for keyboard accessibility.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -44,8 +44,8 @@ export default function CategorySection({
           <div className="relative">
             <button
               onClick={() => setShowMenu((v) => !v)}
-              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none"
-              aria-label="Category options"
+              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:outline-none rounded-md"
+              aria-label={`Options for ${category.name}`}
             >
               •••
             </button>
@@ -89,7 +89,8 @@ export default function CategorySection({
                 onClick={() => onToggleFavorite(item)}
                 disabled={isPending}
                 title={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50"
+                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-yellow-400 focus-visible:outline-none rounded-sm"
+                aria-label={`${item.isFavorite ? 'Remove' : 'Add'} ${item.name} ${item.isFavorite ? 'from' : 'to'} favorites`}
               >
                 {item.isFavorite ? (
                   '⭐'
@@ -118,7 +119,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:opacity-100 focus-visible:outline-none"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +140,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:opacity-100 focus-visible:outline-none"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What: Added aria-labels and focus-visible states to the category overflow menu, favorite toggle, edit item button, and delete item button within the inventory CategorySection.
🎯 Why: These interactive, icon-only, and hover-revealed elements previously lacked context for screen readers and were untabbable for keyboard-only users, preventing full accessibility.
♿ Accessibility: Ensures that keyboard users can navigate to these actions and that screen readers announce specific targets like 'Edit [Item Name]' rather than just 'Edit item'.

---
*PR created automatically by Jules for task [10317698682306129631](https://jules.google.com/task/10317698682306129631) started by @mvng*