### PR TITLE
🔍 Scout: Fix Open Graph URL inheritance and add canonical links

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-10-24 - [Fix Next.js OpenGraph URL Inheritance]
+**Learning:** In Next.js App Router, hardcoding `openGraph: { url: '...' }` in the root `app/layout.tsx` causes all child pages to incorrectly inherit the homepage's Open Graph URL for social sharing.
+**Action:** Remove `url` from global Open Graph configuration and rely on a global `metadataBase` combined with page-specific `alternates: { canonical: '...' }` so Next.js correctly auto-populates `og:url` for each page.

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -1,8 +1,14 @@
 import { Metadata } from 'next'
 
+// SCOUT SEO RATIONALE:
+// Adding page-specific canonical URLs prevents Next.js from merging static
+// canonicals down to all child pages, ensuring correct indexing and og:url generation.
 export const metadata: Metadata = {
   title: 'Sign In or Create Account | Packwise',
   description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
+  alternates: {
+    canonical: '/login',
+  },
   openGraph: {
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -8,6 +8,8 @@ import type { Metadata } from 'next'
 // Adding dynamic metadata to the claim page ensures that when users share this link
 // via social media or messaging apps, the Open Graph preview accurately reflects
 // the trip destination and context, significantly improving click-through rates.
+// Additionally, adding page-specific canonical URLs prevents Next.js from merging static
+// canonicals down to all child pages, ensuring correct indexing and og:url generation.
 export async function generateMetadata({
   params,
 }: {
@@ -41,6 +43,9 @@ export async function generateMetadata({
     return {
       title,
       description,
+      alternates: {
+        canonical: `/claim/${resolvedParams.token}`,
+      },
       openGraph: {
         title,
         description,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,6 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,16 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+import { Metadata } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Adding page-specific canonical URLs prevents Next.js from merging static
+// canonicals down to all child pages, ensuring correct indexing and og:url generation.
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+}
 
 export default async function HomePage() {
   const supabase = await createClient()


### PR DESCRIPTION
💡 **What:** Removed the hardcoded `url` property from the `openGraph` object in `app/layout.tsx` and explicitly added `alternates: { canonical: ... }` definitions to individual pages (e.g., `app/page.tsx`, `app/(auth)/login/layout.tsx`, `app/claim/[token]/page.tsx`).

🎯 **Why:** In Next.js App Router, hardcoding `openGraph: { url: '...' }` in the root `layout.tsx` causes all child pages to incorrectly inherit the homepage's URL in their social sharing previews. By removing this and relying on a global `metadataBase` combined with page-specific canonicals, Next.js can correctly and automatically populate the `og:url` property for each individual page. This also establishes proper canonicalization for indexing.

📊 **Impact:** Prevents duplicate `og:url` and canonical URL signals, ensuring correct indexing and accurate social media unfurling previews for all application routes, especially dynamic share links.

🔬 **Verification:** Validated that Next.js now auto-generates the `og:url` correctly based on the canonical link by confirming code structure, and ran `pnpm lint` and `pnpm test` to verify no regressions were introduced.

🔗 **References:** [Next.js Metadata Object Documentation (OpenGraph)](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#opengraph)

---
*PR created automatically by Jules for task [2663123016001943840](https://jules.google.com/task/2663123016001943840) started by @mvng*