### PR TITLE
⚡ Bolt: Optimize Trip Progress API with Prisma GroupBy

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-18 - Type strictness with Prisma Transactions
 **Learning:** When collecting different Prisma operations (like `.update` and `.create`) into an array to be executed by `prisma.$transaction()`, explicitly typing the array as `Promise<any>[]` will cause a TypeScript build failure. Prisma requires `PrismaPromise`, which has internal brand properties that native Promises lack.
 **Action:** When building dynamic arrays of Prisma operations for transactions, type the array explicitly as `any[]` (or strictly as `PrismaPromise<any>[]` if all elements conform) to prevent build failures during `next build`.
+
+## 2025-03-24 - GroupBy Memory Optimization
+**Learning:** When fetching deeply nested Prisma lists purely to compute counts or sums (like trip packing progress across categories and items), the `include: { items: true }` directive triggers a massive Cartesian product that bloats Node.js memory.
+**Action:** Replace the `include` with parallel queries using `prisma.model.groupBy()` and `prisma.model.findMany()`, reducing the aggregated results into a `Map` in application memory to achieve fast O(1) lookups instead of expensive nested loops.

--- a/app/api/trips/[id]/progress/route.ts
+++ b/app/api/trips/[id]/progress/route.ts
@@ -28,39 +28,54 @@ export async function GET(
       return NextResponse.json({ error: 'Trip not found' }, { status: 404 })
     }
 
-    const categories = await prisma.category.findMany({
-      where: {
-        packingList: {
-          tripId: id
-        }
-      },
-      include: {
-        items: true
+    // ⚡ Bolt Performance Optimization
+    // Why: Flattened Cartesian product Prisma query into parallel aggregate queries.
+    // Replaced `include: { items: true }` with a fast O(1) memory map built from grouped sums.
+    // Impact: Avoids N+1 memory bloat and speeds up progress calculation.
+    const [categories, itemsAggregates] = await Promise.all([
+      prisma.category.findMany({
+        where: { packingList: { tripId: id } },
+        select: { id: true, name: true }
+      }),
+      prisma.packingItem.groupBy({
+        by: ['categoryId', 'isPacked'],
+        where: { category: { packingList: { tripId: id } } },
+        _sum: { quantity: true }
+      })
+    ]);
+
+    const aggregatesMap = new Map<string, { total: number, packed: number }>();
+
+    itemsAggregates.forEach(agg => {
+      const catId = agg.categoryId;
+      const quantity = agg._sum.quantity || 0;
+
+      if (!aggregatesMap.has(catId)) {
+        aggregatesMap.set(catId, { total: 0, packed: 0 });
       }
-    })
+
+      const stats = aggregatesMap.get(catId)!;
+      stats.total += quantity;
+
+      if (agg.isPacked) {
+        stats.packed += quantity;
+      }
+    });
 
     let total = 0
     let packed = 0
     const byCategory: { name: string, total: number, packed: number }[] = []
 
     categories.forEach(category => {
-      let catTotal = 0
-      let catPacked = 0
+      const stats = aggregatesMap.get(category.id) || { total: 0, packed: 0 };
 
-      category.items.forEach(item => {
-        catTotal += item.quantity
-        if (item.isPacked) {
-          catPacked += item.quantity
-        }
-      })
-
-      total += catTotal
-      packed += catPacked
+      total += stats.total;
+      packed += stats.packed;
 
       byCategory.push({
         name: category.name,
-        total: catTotal,
-        packed: catPacked
+        total: stats.total,
+        packed: stats.packed
       })
     })
 


### PR DESCRIPTION
💡 What: Flattened deeply nested Cartesian product Prisma queries in `app/api/trips/[id]/progress/route.ts` into parallel aggregate queries utilizing `prisma.packingItem.groupBy`. Reduced array loops into a `Map` lookup for categories.

🎯 Why: To calculate the progress bar, the original query requested `include: { items: true }`, forcing Postgres to construct a massive Cartesian product of relations across the network and severely bloating Node.js application memory. 

📊 Impact: Massively reduces peak heap memory overhead on the Next.js API server and decreases database execution/serialization time.

🔬 Measurement: Local testing and Playwright tests verify logic remains 100% correct, generating identical frontend responses for completion calculations.

---
*PR created automatically by Jules for task [5436121428554754149](https://jules.google.com/task/5436121428554754149) started by @mvng*