### PR TITLE
🔍 Scout: Fix inherited Open Graph URLs and add canonical tags

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,7 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+
+## 2024-06-29 - [Fix Open Graph URL Inheritance]
+**Learning:** In Next.js App Router, hardcoding `openGraph: { url: '...' }` in the root `app/layout.tsx` causes all child pages to incorrectly inherit the homepage's Open Graph URL for social sharing.
+**Action:** Rely on defining a global `metadataBase` combined with page-specific `alternates: { canonical: '...' }`, which allows Next.js to automatically and correctly populate the `og:url` for every page.

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -1,8 +1,15 @@
 import { Metadata } from 'next'
 
+// SCOUT SEO RATIONALE:
+// Adding a canonical tag specifically for the login page prevents duplicate content issues
+// if the page is accessed via query parameters (e.g. tracking codes) and helps Next.js
+// accurately construct the `og:url` without incorrectly inheriting the homepage's URL.
 export const metadata: Metadata = {
   title: 'Sign In or Create Account | Packwise',
   description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
+  alternates: {
+    canonical: '/login',
+  },
   openGraph: {
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -38,9 +38,15 @@ export async function generateMetadata({
       ? `Join the shared packing list for ${list.trip.destination}. Claim the items you're bringing!`
       : `Join this shared packing list on Packwise. Claim the items you're bringing!`
 
+    // SCOUT SEO RATIONALE:
+    // We add a dynamic canonical URL here to ensure that Next.js properly constructs the correct `og:url`
+    // for this specific shared list. This prevents social platforms from incorrectly caching the homepage URL.
     return {
       title,
       description,
+      alternates: {
+        canonical: `/claim/${resolvedParams.token}`,
+      },
       openGraph: {
         title,
         description,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,11 @@ import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
 
+// SCOUT SEO RATIONALE:
+// Removing the hardcoded `url` property from the `openGraph` object. By doing this,
+// child pages will no longer incorrectly inherit the homepage's specific Open Graph URL.
+// Instead, Next.js will automatically generate the correct `og:url` for each page
+// by combining the `metadataBase` defined here with the page-specific canonical URL.
 export const metadata: Metadata = {
   metadataBase: new URL('https://packwise-indol.vercel.app'),
   title: 'Packwise – Smart Packing Lists',
@@ -15,7 +20,6 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,17 @@
+import { Metadata } from 'next'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+
+// SCOUT SEO RATIONALE:
+// Adding a page-specific canonical tag to the homepage explicitly marks it as the primary version
+// of this content, preventing duplicate content issues if accessed via different query params.
+// Next.js will automatically use this to populate the `og:url` for the homepage.
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+}
 
 export default async function HomePage() {
   const supabase = await createClient()


### PR DESCRIPTION
💡 **What:**
- Removed the hardcoded `url` from the global `openGraph` object in the root `app/layout.tsx`.
- Added page-specific `alternates: { canonical: '...' }` to the homepage (`app/page.tsx`), login page (`app/(auth)/login/layout.tsx`), and claim page (`app/claim/[token]/page.tsx`).
- Added explanatory inline comments detailing the SEO rationale for these changes.

🎯 **Why:**
In Next.js App Router, hardcoding `openGraph: { url: '...' }` in the root layout causes all child pages to incorrectly inherit the homepage's Open Graph URL. This breaks link unfurling and social sharing for specific pages, as platforms cache the homepage URL instead. By defining a global `metadataBase` and page-specific canonical URLs, Next.js can correctly auto-populate the `og:url` for every page.

📊 **Impact:**
- Fixes social sharing previews (Open Graph and Twitter Cards) for all child pages, especially shared packing list links (`/claim/[token]`).
- Prevents duplicate content issues and improves indexing precision by correctly identifying the primary version of each page via canonical tags.

🔬 **Verification:**
- Verified via `pnpm test` and `pnpm lint` that the changes introduce no regressions.
- The `og:url` for shared claim pages will now correctly point to the specific tokenized URL, which can be verified using the Twitter Card Validator or LinkedIn Post Inspector when deployed.

🔗 **References:**
- Next.js Metadata API Documentation on `metadataBase` and `alternates`.

---
*PR created automatically by Jules for task [13689377281010755936](https://jules.google.com/task/13689377281010755936) started by @mvng*