### PR TITLE
🎨 Palette: Improve TaskCard accessibility and keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve accessibility of hover-revealed action buttons
+**Learning:** The codebase has a recurring accessibility issue pattern across multiple components where hover-revealed icon-only buttons are managed by React state and lack ARIA labels and explicit focus states, making them inaccessible to screen reader and keyboard users.
+**Action:** Replace React hover state with CSS parent-child styling like `group-hover:opacity-100` and `focus-within:opacity-100`, and always add context-specific `aria-label` attributes and `focus-visible:ring-2` classes to interactive elements.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,21 +20,19 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? `Mark "${task.title}" as incomplete` : `Mark "${task.title}" as complete`}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,17 +67,19 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            aria-label={`Edit "${task.title}"`}
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            aria-label={`Delete "${task.title}"`}
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
           >
             <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
💡 **What**: Refactored the `TaskCard` component to use CSS `group-hover` and `focus-within` instead of explicit React `useState` for hover interactions. Added context-aware `aria-label`s to the toggle, edit, and delete action buttons, along with explicit `focus-visible` styling.

🎯 **Why**: Previously, the hover-revealed action buttons were inaccessible to keyboard and screen reader users because they lacked ARIA labels, focus states, and their visibility was tied to pointer events (`onMouseEnter`). This change fixes those accessibility gaps while simultaneously simplifying the component by removing unnecessary React state.

📸 **Before/After**:
Before: Hover actions hidden from keyboard users, lacking descriptive labels.
After: Hover actions visible on focus via `focus-within`, with clear `aria-label`s (e.g., `Edit "Book flights"`) and distinct focus rings.

♿ **Accessibility**:
- Added descriptive `aria-label`s to icon-only buttons (complete/incomplete toggle, edit, delete).
- Added explicit `focus-visible:ring-2` to guarantee visible focus states.
- Replaced JS hover tracking with CSS `focus-within:opacity-100` to ensure buttons become visible when a keyboard user tabs into them.

---
*PR created automatically by Jules for task [2977019810198204547](https://jules.google.com/task/2977019810198204547) started by @mvng*