### PR TITLE
🔍 Scout: [Fix Open Graph URL inheritance]

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-03-16 - [Hardcoded Open Graph URL Inheritance]
+**Learning:** Hardcoding `openGraph: { url: '...' }` in the root `app/layout.tsx` causes all child pages to incorrectly inherit the homepage's Open Graph URL for social sharing.
+**Action:** Always rely on defining a global `metadataBase` combined with page-specific `alternates: { canonical: '...' }` instead of hardcoding the URL in the root layout, which allows Next.js to automatically and correctly populate the `og:url` for every page.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
+
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,13 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+}
 
 export default async function HomePage() {
   const supabase = await createClient()


### PR DESCRIPTION
💡 **What:** 
Removed the hardcoded `url: 'https://packwise-indol.vercel.app'` from the global `openGraph` object in `app/layout.tsx` and added `alternates: { canonical: '/' }` to the homepage (`app/page.tsx`).

🎯 **Why:** 
Hardcoding the Open Graph URL in the root layout causes all child pages (like dynamic share links) to inherit the homepage's URL. This results in incorrect social sharing metadata for child pages. By relying on the global `metadataBase` and page-specific canonicals, Next.js will automatically populate the correct `og:url` for each route.

📊 **Impact:** 
Ensures that when users share specific pages (like a dynamic packing list or a trip claim page), the Open Graph preview accurately points to the shared page instead of the homepage, improving link unfurling and CTR.

🔬 **Verification:** 
- The project successfully compiles and passes tests. 
- You can confirm the fix by inspecting the `<meta property="og:url">` tag on any child page (it should now match the specific route rather than the homepage).

🔗 **References:** 
Next.js Metadata Documentation: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadata-object

---
*PR created automatically by Jules for task [16774809901637450312](https://jules.google.com/task/16774809901637450312) started by @mvng*