### PR TITLE
🎨 Palette: Add ARIA labels and focus states to Inventory item actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-06-30 - Add ARIA labels to hover-revealed buttons in Inventory
+**Learning:** Identified an accessibility issue pattern where hover-revealed action buttons in item lists (like CategorySection) lack specific `aria-label`s interpolating the item name, leaving screen reader users without context, and missing focus-visible rings for keyboard navigation.
+**Action:** Always ensure hover-revealed action buttons in item lists have descriptive `aria-label`s incorporating the item's context (e.g., `aria-label={"Edit " + item.name}`) and explicit `focus-visible:ring-2` utility classes.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -118,7 +118,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What: Added an `aria-label` and `focus-visible` ring classes to the "Edit item" button within the `CategorySection` component.

🎯 Why: The "Edit item" button is a hover-revealed action without visible text, meaning screen readers would announce it simply as "button". Adding `aria-label={"Edit " + item.name}` interpolates the item's name to give users with assistive technology the context they need. In addition, providing a clear `focus-visible` outline ensures that keyboard users can locate the button when tabbing through the list.

📸 Before/After: N/A - Visual change only affects the focus state, but DOM changes drastically improve semantic meaning.

♿ Accessibility:
- Improves Screen Reader experience by adding dynamic contextual `aria-label`s.
- Improves Keyboard navigation support by explicitly adding focus indicators (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500`).

---
*PR created automatically by Jules for task [1686890298206525904](https://jules.google.com/task/1686890298206525904) started by @mvng*