### PR TITLE
🎨 Palette: Add accessible actions to inventory category items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Add accessible actions to inventory category items
+**Learning:** Found a recurring accessibility pattern in CategorySection where hover-revealed icon-only buttons (Edit/Delete) lack `aria-label`s and `focus-visible` styles, rendering them invisible to screen readers and keyboard users.
+**Action:** Always ensure icon-only buttons, especially those revealed on hover, have descriptive context-specific `aria-label` attributes and explicit `focus-visible` utility classes (e.g., `focus-visible:ring-2`) to guarantee discoverability and triggerability.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -118,7 +118,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:opacity-100"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +139,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:opacity-100"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What: Added context-specific `aria-label` attributes and explicit `focus-visible` utility classes (e.g., `focus-visible:ring-2`) to the hover-revealed Edit and Delete buttons in the Inventory Category section (`CategorySection.tsx`).

🎯 Why: Previously, the icon-only Edit and Delete buttons were missing `aria-label`s, rendering them invisible to screen readers. Furthermore, since their visibility is often tied to hover states, explicit `focus-visible` styles are necessary to ensure keyboard-only users can discover and trigger these actions while navigating the list.

📸 Before/After: Not a visual change for pointer users, but the `focus-visible` ring provides a clear visual indicator for keyboard navigation.

♿ Accessibility: Ensures that interactive elements, particularly icon-only buttons, are discoverable and actionable by all users, including those relying on screen readers and keyboard navigation.

References: Added learning to `.Jules/palette.md` regarding recurring patterns of missing ARIA labels on hover-revealed icon-only actions.

---
*PR created automatically by Jules for task [1360769173960457029](https://jules.google.com/task/1360769173960457029) started by @mvng*