### PR TITLE
🎨 Palette: Add ARIA labels and focus states to inventory actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-07-02 - Add missing ARIA labels to hover-revealed inventory item actions
+**Learning:** The accessibility issue pattern of missing `aria-label`s and `focus-visible` styles on hover-revealed icon buttons is widespread, affecting the Inventory Category list (`CategorySection.tsx`). Screen reader users lack context on what "Edit" or "Delete" refers to without interpolating the item name.
+**Action:** When working on lists with item-specific actions, always ensure buttons interpolate the item's name (e.g., `aria-label="Edit ${item.name}"`) and include explicit `focus-visible` styles for keyboard navigability.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -89,7 +89,8 @@ export default function CategorySection({
                 onClick={() => onToggleFavorite(item)}
                 disabled={isPending}
                 title={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50"
+                aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`}
+                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 rounded"
               >
                 {item.isFavorite ? (
                   '⭐'
@@ -118,7 +119,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:opacity-100"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +140,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:opacity-100"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What: Added missing `aria-label` and explicit `focus-visible` ring styling to the Favorite, Edit, and Delete hover-revealed icon buttons within the Inventory Category list (`components/inventory/CategorySection.tsx`).

🎯 Why: To dramatically improve accessibility for keyboard and screen reader users navigating the inventory lists. Without these, it's impossible to understand the context of the buttons or see which one has focus.

📸 Before/After: Hover-revealed action buttons lacked labels. Now, screen readers will hear interpolations like "Edit Rain jacket" instead of "button", and keyboard navigation clearly highlights the targeted icon.

♿ Accessibility: Ensures WCAG compliance for interactive elements by addressing missing accessible names and ensuring keyboard discoverability.

---
*PR created automatically by Jules for task [13379695326203834898](https://jules.google.com/task/13379695326203834898) started by @mvng*