### PR TITLE
🔍 Scout: Fix Open Graph URL inheritance

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-07-02 - [Next.js Open Graph URL Inheritance]
+**Learning:** In Next.js App Router, hardcoding `openGraph: { url: '...' }` in the root `app/layout.tsx` causes all child pages to incorrectly inherit the homepage's Open Graph URL for social sharing.
+**Action:** Rely on defining a global `metadataBase` combined with page-specific `alternates: { canonical: '...' }` in page-specific metadata, which allows Next.js to automatically and correctly populate the `og:url` for every page.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,12 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
+    // SCOUT SEO RATIONALE:
+    // Removed hardcoded `url` from global openGraph metadata.
+    // In Next.js App Router, hardcoding this here causes all child pages
+    // to incorrectly inherit the homepage's Open Graph URL for social sharing.
+    // Instead, Next.js will automatically populate og:url for every page based
+    // on `metadataBase` combined with page-specific `alternates: { canonical: ... }`.
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,17 @@
+import { Metadata } from 'next'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+
+// SCOUT SEO RATIONALE:
+// Adding page-specific canonical URL. Since `metadataBase` is defined in `layout.tsx`,
+// Next.js will automatically combine it with this canonical path and correctly populate
+// both the `<link rel="canonical">` and `og:url` for the homepage.
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+}
 
 export default async function HomePage() {
   const supabase = await createClient()


### PR DESCRIPTION
💡 **What:** Removed the hardcoded `url` property from the global `openGraph` object in `app/layout.tsx` and added a page-specific canonical URL (`alternates: { canonical: '/' }`) to `app/page.tsx`.
🎯 **Why:** In Next.js App Router, placing a hardcoded `url` in the root `layout.tsx`'s `openGraph` metadata forces all child pages to inherit that exact URL. This breaks link unfurling and social sharing for all internal pages (e.g., shareable packing lists) because they incorrectly appear as the homepage. By relying on Next.js's built-in combination of `metadataBase` and page-specific `alternates.canonical`, the `og:url` is automatically and correctly populated for every unique route.
📊 **Impact:** Ensures accurate Open Graph URL generation across the entire application, significantly improving social sharing accuracy and click-through rates for dynamic and internal pages.
🔬 **Verification:** Verified by checking that `app/layout.tsx` no longer has the hardcoded `url`, `app/page.tsx` now has the canonical alternate, and all existing tests pass (`pnpm test`).
🔗 **References:** [Next.js Metadata Documentation](https://nextjs.org/docs/app/building-your-application/optimizing/metadata#metadatabase)

---
*PR created automatically by Jules for task [11059759343616988370](https://jules.google.com/task/11059759343616988370) started by @mvng*