### PR TITLE
🎨 Palette: Make TaskCard action buttons accessible via keyboard and screen reader

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Avoid React state for hover-revealed actions
+**Learning:** Using React state (`onMouseEnter`/`onMouseLeave`) to manage hover-revealed UI elements often misses keyboard focus events.
+**Action:** Use CSS parent-child styling like `group-hover:opacity-100` combined with `focus-within:opacity-100` to inherently support keyboard focus visibility.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,21 +20,19 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
+          aria-label={isDone ? 'Mark task as incomplete' : 'Mark task as complete'}
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,17 +67,19 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
           <button
+            aria-label="Edit task"
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
+            aria-label="Delete task"
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
           >
             <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
### 💡 What:
Improved the accessibility and UX of the `TaskCard` component by refactoring how hover-revealed actions are managed and adding semantic ARIA labels.
- Removed `isHovered` React state and replaced it with Tailwind CSS `group`, `group-hover:opacity-100`, and `focus-within:opacity-100`.
- Added descriptive `aria-label` attributes to the status toggle, edit, and delete icon-only buttons.
- Added `focus-visible` utility classes to ensure a focus ring appears during keyboard navigation.

### 🎯 Why:
The previous implementation tied the visibility of the "Edit" and "Delete" buttons strictly to mouse `onMouseEnter` and `onMouseLeave` events. This completely hid the buttons from keyboard-only users who tab through the interface. Additionally, icon-only buttons lacked `aria-label`s, rendering them meaningless to screen readers. 

By switching to CSS parent-child styling and adding ARIA attributes, the component is now fully discoverable and interactable via keyboard and assistive technologies. As an added bonus, removing React state prevents unnecessary component re-renders during mouse hover.

### 📸 Before/After:
**Before:** Actions only visible on mouse hover, unreachable via keyboard tab navigation, missing ARIA context.
**After:** Actions inherently support keyboard focus visibility, screen readers read explicit intents (e.g. "Edit task", "Mark task as complete"), and focus rings appear for visual clarity.

### ♿ Accessibility:
- Added `focus-within:opacity-100` to action container.
- Added `aria-label`s to all icon-only buttons.
- Added `focus-visible:ring-2` to all interactive elements for clear keyboard focus indications.

---
*PR created automatically by Jules for task [15136370533064931246](https://jules.google.com/task/15136370533064931246) started by @mvng*