### PR TITLE
🔍 Scout: Fix inherited Open Graph URLs via page-specific canonicals

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-07-03 - [Next.js App Router Hardcoded openGraph URL]
+**Learning:** Hardcoding `openGraph: { url: '...' }` in the root `app/layout.tsx` is an anti-pattern that causes all child pages to incorrectly inherit the homepage's Open Graph URL. By defining a global `metadataBase` and setting page-specific `alternates: { canonical: '...' }` on child routes, Next.js automatically and correctly populates the `og:url` for every individual page.
+**Action:** Never hardcode `url` in the root `openGraph` object. Instead, configure `metadataBase` globally and define `alternates: { canonical: '...' }` on specific pages to ensure proper social sharing metadata inheritance.

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -7,6 +7,11 @@ export const metadata: Metadata = {
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   },
+  // SCOUT SEO RATIONALE: Adding page-specific canonical URL to ensure Next.js
+  // correctly generates the og:url using the global metadataBase.
+  alternates: {
+    canonical: '/login',
+  },
 }
 
 export default function LoginLayout({

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -51,6 +51,11 @@ export async function generateMetadata({
         title,
         description,
       },
+      // SCOUT SEO RATIONALE: Adding page-specific canonical URL to ensure Next.js
+      // correctly generates the og:url using the global metadataBase.
+      alternates: {
+        canonical: `/claim/${resolvedParams.token}`,
+      },
     }
   } catch (error) {
     return {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,8 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
+    // SCOUT SEO RATIONALE: Removed hardcoded `url` so Next.js automatically derives `og:url`
+    // for every page via `metadataBase` and page-specific `alternates.canonical`
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,15 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+import { Metadata } from 'next'
+
+// SCOUT SEO RATIONALE: Adding page-specific canonical URL to ensure Next.js
+// correctly generates the og:url using the global metadataBase.
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+}
 
 export default async function HomePage() {
   const supabase = await createClient()

--- a/app/trip/[id]/layout.tsx
+++ b/app/trip/[id]/layout.tsx
@@ -40,6 +40,11 @@ export async function generateMetadata({
         title,
         description,
       },
+      // SCOUT SEO RATIONALE: Adding page-specific canonical URL to ensure Next.js
+      // correctly generates the og:url using the global metadataBase.
+      alternates: {
+        canonical: `/trip/${resolvedParams.id}`,
+      },
     }
   } catch (error) {
     return {


### PR DESCRIPTION
💡 **What:** 
Removed the hardcoded `openGraph.url` in `app/layout.tsx` and added page-specific canonical URLs via the `alternates.canonical` metadata property to `app/page.tsx`, `app/(auth)/login/layout.tsx`, `app/claim/[token]/page.tsx`, and `app/trip/[id]/layout.tsx`.

🎯 **Why:** 
Hardcoding the Open Graph URL in the root layout is an SEO anti-pattern that causes all child pages to incorrectly tell social media crawlers and search engines that they are the homepage. This leads to duplicate content issues and incorrect link unfurls when users share specific pages (like shared trips). By defining a global `metadataBase` and page-specific canonicals, Next.js automatically and correctly derives the `og:url` for every page.

📊 **Impact:** 
Resolves duplicate social sharing URLs across the application. When users share a specific trip or the claim page, the preview card will correctly link back to that specific entity rather than redirecting or attributing it to the homepage. This ensures proper crawl indexing and improves CTR for shared links.

🔬 **Verification:** 
Verified by running `pnpm lint` and the Playwright test suite (`pnpm test`). The code modifications successfully preserve all functionality, and manual inspection confirms the metadata structure correctly adheres to Next.js guidelines.

🔗 **References:** 
- [Next.js Metadata Object - alternates](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#alternates)
- [Next.js Metadata Object - metadataBase](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase)

---
*PR created automatically by Jules for task [8025610274610701993](https://jules.google.com/task/8025610274610701993) started by @mvng*