### PR TITLE
🎨 Palette: [UX improvement] Enhance accessibility of inventory category list item actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Add accessible ARIA labels and focus rings to inventory list actions
+**Learning:** Identified a recurring accessibility pattern where icon-only action buttons in mapped lists (like the Favorite, Edit, and Delete buttons in the Inventory Category section) lacked context-specific `aria-label`s (interpolating the item name) and explicit `focus-visible` rings. The Edit and Delete buttons were only discoverable via hover and lacked proper keyboard focus styles.
+**Action:** Always ensure that hover-revealed action buttons and list item controls include descriptive, item-specific `aria-label` attributes and explicit `focus-visible` utility classes to guarantee they are discoverable and triggerable by screen reader and keyboard users.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -44,7 +44,7 @@ export default function CategorySection({
           <div className="relative">
             <button
               onClick={() => setShowMenu((v) => !v)}
-              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none"
+              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded"
               aria-label="Category options"
             >
               •••
@@ -89,7 +89,8 @@ export default function CategorySection({
                 onClick={() => onToggleFavorite(item)}
                 disabled={isPending}
                 title={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50"
+                aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`}
+                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded"
               >
                 {item.isFavorite ? (
                   '⭐'
@@ -118,7 +119,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +140,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 **What:**
Added context-aware `aria-label` attributes to the "Favorite", "Edit", and "Delete" icon-only buttons in the `CategorySection` list items. Also added explicit `focus-visible` Tailwind utility classes (like `focus-visible:ring-2 focus-visible:ring-gray-400`) to the category options button and the list item action buttons. Added a journal entry logging this pattern.

🎯 **Why:**
Previously, the icon-only action buttons within the inventory category lists had no descriptive text for screen readers (leaving them unable to understand what item the action applies to) and were heavily reliant on pointer `hover` events. Adding explicit focus rings ensures keyboard navigators can discover and trigger these actions smoothly, and the ARIA labels provide crucial context for assistive technologies.

📸 **Before/After:**
*(Visual focus rings now appear when tab-navigating over these controls)*

♿ **Accessibility:**
- Added descriptive `aria-label` attributes with interpolated item names (e.g., "Edit Laptop").
- Implemented explicit keyboard focus styles for interactable elements inside mapped lists.

---
*PR created automatically by Jules for task [13459812737034458364](https://jules.google.com/task/13459812737034458364) started by @mvng*