### PR TITLE
🎨 Palette: Add accessible labels and focus states to inventory items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+
+## 2024-07-04 - Hover-Revealed Icon Buttons Missing Accessible Names and Focus States
+**Learning:** Found a recurring accessibility issue pattern across multiple app components (e.g. `CategorySection` and `PackingListSection`) where hover-revealed icon-only buttons lacked descriptive context-specific `aria-label` attributes and explicit `focus-visible` states, making them undiscoverable and untriggerable for screen reader and keyboard users.
+**Action:** When designing hover-revealed action buttons, always ensure they are accompanied by context-specific `aria-label`s (e.g. `aria-label="Edit ${item.name}"`) and explicit `focus-visible:ring-2` utility classes to guarantee keyboard focus is visible.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -44,8 +44,8 @@ export default function CategorySection({
           <div className="relative">
             <button
               onClick={() => setShowMenu((v) => !v)}
-              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none"
-              aria-label="Category options"
+              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded-md"
+              aria-label={`Options for ${category.name}`}
             >
               •••
             </button>
@@ -89,7 +89,8 @@ export default function CategorySection({
                 onClick={() => onToggleFavorite(item)}
                 disabled={isPending}
                 title={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50"
+                aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`}
+                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded-md"
               >
                 {item.isFavorite ? (
                   '⭐'
@@ -118,7 +119,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +140,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 **What:** 
Added context-specific `aria-label` attributes and Tailwind `focus-visible` utility classes to the icon-only buttons in the `CategorySection` component (Options, Favorite, Edit, and Delete).

🎯 **Why:** 
Previously, these buttons (especially those only revealed on hover, like Edit and Delete) lacked accessible names and clear focus states, making them undiscoverable and untriggerable for screen reader users and those navigating via keyboard. These enhancements make the component fully accessible.

📸 **Before/After:**
*Before:* Hover-only buttons lacked `focus-visible` styling, preventing keyboard users from identifying when they had focus.
*After:* A clear `ring-2` outline appears when navigating to these buttons using the `Tab` key, and screen readers read specific labels like "Edit [Item Name]" instead of generic or missing text.

♿ **Accessibility:**
- Added specific `aria-label`s to the Favorite toggle (e.g., "Add [Item Name] to favorites").
- Added specific `aria-label`s to the Edit and Delete buttons.
- Added `aria-label` to the Category Options menu button.
- Added `focus-visible:ring-2 focus-visible:ring-gray-400` (and `ring-red-400` for Delete) to all interactive elements in the component to ensure keyboard navigability.

---
*PR created automatically by Jules for task [2839887710592267166](https://jules.google.com/task/2839887710592267166) started by @mvng*