### PR TITLE
🔧 Fix: redirect to forked trip after login

### DIFF
--- a/.jules/felix.md
+++ b/.jules/felix.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - Handle post-login redirects stored in sessionStorage
+**Learning:** When implementing custom post-login redirects in Next.js (e.g., redirecting a user to a newly forked trip), verify `sessionStorage` for stored redirect intents and process them completely before falling back to default routing (like `window.location.href = '/dashboard'`), ensuring the default route does not prematurely override the intended redirect flow.
+**Action:** Always check `sessionStorage` or redirect URL parameters for intent before applying default auth routing.

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
+import { forkTrip } from '@/actions/trip.actions'
+import { getTripLocalStorageState } from '@/components/PackingListSection'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -11,6 +13,28 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [message, setMessage] = useState<string | null>(null)
+
+  const handleLoginSuccess = async () => {
+    const pendingForkTripId = sessionStorage.getItem('fork_trip_after_login')
+    if (pendingForkTripId) {
+      try {
+        const localStorageState = getTripLocalStorageState(pendingForkTripId)
+        const result = await forkTrip(pendingForkTripId, localStorageState)
+
+        if (result.success && result.tripId) {
+          sessionStorage.removeItem('fork_trip_after_login')
+          localStorage.removeItem(`packwise_trip_${pendingForkTripId}`)
+          window.location.href = `/trip/${result.tripId}`
+          return
+        }
+      } catch (err) {
+        console.error('Failed to fork trip after login:', err)
+      }
+    }
+
+    // Fallback if no pending fork or fork failed
+    window.location.href = '/dashboard'
+  }
 
   const handleAuth = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -36,7 +60,7 @@ export default function LoginPage() {
       // If email confirmation is disabled, signUp returns a valid session.
       // Redirect immediately to dashboard (the auth callback will upsert the Prisma User).
       if (data?.session) {
-        window.location.href = '/dashboard'
+        await handleLoginSuccess()
         return
       }
 
@@ -49,7 +73,7 @@ export default function LoginPage() {
         setLoading(false)
         return
       }
-      window.location.href = '/dashboard'
+      await handleLoginSuccess()
       return
     }
     setLoading(false)


### PR DESCRIPTION
🐛 **Issue:** Closes #545. When an unauthenticated user tried to fork a shared trip, they were correctly redirected to login with their intent stored in `sessionStorage`. However, the login page's `handleAuth` function ignored this intent and unconditionally redirected them to `/dashboard` upon a successful login or signup.
🔍 **Root Cause:** The client-side `signInWithPassword` and `signUp` handlers in `app/(auth)/login/page.tsx` were hardcoded to route to `/dashboard` upon success, ignoring the `fork_trip_after_login` key set by the `ForkTripButton`.
🛠️ **Fix:** Implemented a `handleLoginSuccess` callback in `app/(auth)/login/page.tsx`. This callback explicitly checks `sessionStorage` for the `fork_trip_after_login` key. If present, it executes the `forkTrip` Server Action (restoring any local state), clears the session and local storage, and then redirects the user directly to their new forked trip page. If the key is absent or the fork operation fails, it gracefully falls back to the `/dashboard` redirect.
✅ **Verification:** Verified via `pnpm lint` and `pnpm test`. The changes properly handle the client-side redirect and effectively clear local state without polluting existing auth flows.
⚠️ **Notes:** Using `window.location.href` to trigger the final redirection forces a full-page reload, ensuring any auth state changes are fully picked up by Server Components on the newly rendered trip page.

---
*PR created automatically by Jules for task [16878472390931736092](https://jules.google.com/task/16878472390931736092) started by @mvng*