### PR TITLE
🔍 Scout: [Fix Open Graph URL Inheritance]

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2025-02-23 - [Root Layout Open Graph URL Inheritance]
+**Learning:** In Next.js App Router, hardcoding `openGraph: { url: '...' }` in the root `app/layout.tsx` causes all child pages to incorrectly inherit the homepage's Open Graph URL for social sharing.
+**Action:** Rely on defining a global `metadataBase` in the root layout combined with page-specific `alternates: { canonical: '...' }` in `page.tsx` files, allowing Next.js to automatically and correctly populate the `og:url` for every page.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,11 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
+    // SCOUT SEO RATIONALE:
+    // Removed hardcoded 'url' property to prevent all child pages from
+    // incorrectly inheriting the homepage URL for social sharing.
+    // Instead, Next.js uses metadataBase combined with page-specific
+    // alternates.canonical to properly generate og:url.
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,17 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+import type { Metadata } from 'next'
+
+// SCOUT SEO RATIONALE:
+// Adding page-specific canonical URL allows Next.js to combine it with
+// the root metadataBase and dynamically populate the correct og:url
+// without causing child routes to inherit it.
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+}
 
 export default async function HomePage() {
   const supabase = await createClient()


### PR DESCRIPTION
💡 **What:** 
Removed the hardcoded `url` property from the `openGraph` metadata object in `app/layout.tsx` and added a specific `alternates: { canonical: '/' }` in `app/page.tsx`.

🎯 **Why:** 
Hardcoding `openGraph: { url: '...' }` in the root `app/layout.tsx` causes all child pages (e.g., dynamic claim pages, blog posts) to incorrectly inherit the homepage's Open Graph URL. When users share deep links on social media platforms, this misconfiguration causes crawlers to scrape the homepage instead of the specific shared page, breaking rich previews and significantly hurting CTR.

By relying on the global `metadataBase` and defining page-specific canonicals, Next.js can now automatically and correctly generate the `og:url` for every child route dynamically.

📊 **Impact:** 
Ensures correct social sharing previews for all dynamic and nested child pages, improving click-through rates and deep link discoverability.

🔬 **Verification:** 
Verified `app/layout.tsx` and `app/page.tsx` export correctly. `pnpm lint` and `pnpm test` pass. Reviewing `<meta property="og:url" content="...">` in child routes will now correctly point to the specific route instead of the homepage.

🔗 **References:** 
- Next.js Metadata Docs: https://nextjs.org/docs/app/building-your-application/optimizing/metadata#metadatabase
- https://nextjs.org/docs/app/building-your-application/optimizing/metadata#alternates

---
*PR created automatically by Jules for task [13070433125132465915](https://jules.google.com/task/13070433125132465915) started by @mvng*