### PR TITLE
🎨 Palette: Add accessible action buttons to inventory list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Add accessible actions to Inventory Category Section
+**Learning:** Found a pattern where interactive list elements (Favorite, Edit, Delete buttons) in `CategorySection.tsx` lacked keyboard focus indicators (`focus-visible:ring-2`) and context-specific `aria-label` attributes (e.g. `aria-label="Edit item name"`), making them difficult to use for keyboard-only and screen reader users. The "Category options" button also lacked focus indicators.
+**Action:** Always ensure mapped list action buttons include context-interpolated `aria-label`s and explicit `focus-visible` utility classes with appropriate ring colors to guarantee they are accessible and discoverable.

--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -44,8 +44,8 @@ export default function CategorySection({
           <div className="relative">
             <button
               onClick={() => setShowMenu((v) => !v)}
-              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none"
-              aria-label="Category options"
+              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded"
+              aria-label={`Options for ${category.name} category`}
             >
               •••
             </button>
@@ -89,7 +89,8 @@ export default function CategorySection({
                 onClick={() => onToggleFavorite(item)}
                 disabled={isPending}
                 title={item.isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50"
+                aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`}
+                className="text-base leading-none flex-shrink-0 transition-transform hover:scale-110 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 rounded-sm"
               >
                 {item.isFavorite ? (
                   '⭐'
@@ -118,7 +119,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +140,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What:
Added accessible focus states and ARIA labels to the icon-only interactive elements in the `CategorySection` mapped list items.

🎯 Why:
The 'Options', 'Favorite', 'Edit', and 'Delete' icon-only buttons lacked keyboard focus indicators (`focus-visible:ring-2`) and context-specific labels (e.g. `aria-label="Edit Laptop"`), making them effectively unusable for keyboard navigators and confusing for screen reader users relying on semantic context.

📸 Before/After:
Before: Tabbing through the list showed no visual indication of which button was focused. Screen readers would announce "button" or generic titles without context.
After: Tabbing clearly highlights each button with an appropriate colored ring (e.g. yellow for favorite, red for delete). Screen readers now announce actions with context like "Delete Laptop".

♿ Accessibility:
- Added `focus-visible:ring-2` with appropriate colors to all icon buttons.
- Added context-aware `aria-label` attributes to 'Favorite', 'Edit', and 'Delete' buttons.
- Handled the 'Category options' `•••` button focus state.

---
*PR created automatically by Jules for task [6102510133404344522](https://jules.google.com/task/6102510133404344522) started by @mvng*