### PR TITLE
🎨 Palette: Add accessible labels and focus states to packing list buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2025-07-05 - Missing ARIA labels and focus states on icon-only buttons
+**Learning:** Hover-revealed and inline icon-only buttons (like note actions and delete buttons) frequently lack accessible names (`aria-label`) and distinct keyboard focus indicators (`focus-visible`).
+**Action:** Always provide `aria-label` matching the item context (e.g., `Save note for ${item.name}`) and `focus-visible:ring-2` for all icon-only interactions.

--- a/components/PackingListSection.tsx
+++ b/components/PackingListSection.tsx
@@ -725,9 +725,10 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
                         handleUpdateNotes(item.id, item.categoryId, item.packingListId, editingNotes?.notes || "")
                         setEditingNotes(null)
                       }}
-                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                      className="p-1 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                      aria-label={`Save note for ${item.name}`}
                     ><Check className="w-3 h-3" /></button>
-                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200"><X className="w-3 h-3" /></button>
+                    <button onClick={() => setEditingNotes(null)} className="p-1 bg-gray-100 text-gray-500 rounded hover:bg-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-500" aria-label={`Cancel editing note for ${item.name}`}><X className="w-3 h-3" /></button>
                   </div>
                 </div>
               ) : item.notes ? (
@@ -748,23 +749,24 @@ export default function PackingListSection({ trip, readOnly = false, sharedTripL
             <button
               onClick={(e) => { e.preventDefault(); setEditingNotes({ id: item.id, notes: item.notes || '' }) }}
               title="Add/Edit Note"
-              className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 flex items-center justify-center"
+              className="text-xs p-1 rounded-full border bg-white text-gray-400 border-gray-200 hover:border-blue-300 hover:text-blue-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 flex items-center justify-center"
+              aria-label={`Add or edit note for ${item.name}`}
             ><MessageSquare className="w-3.5 h-3.5" /></button>
             <button
               onClick={() => handleTogglePackLast(item.id, item.categoryId, item.packingListId, item.packLast)}
               title={item.packLast ? 'Remove from departure checklist' : 'Add to departure checklist (pack last)'}
-              className={`text-xs p-1 rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 flex items-center justify-center ${
+              className={`text-xs p-1 rounded-full border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 flex items-center justify-center ${
                 item.packLast
                   ? 'bg-amber-100 text-amber-700 border-amber-300'
                   : 'bg-white text-gray-400 border-gray-200 hover:border-amber-300 hover:text-amber-600'
               }`}
-              aria-label={item.packLast ? 'Remove from pack last' : 'Mark as pack last'}
+              aria-label={item.packLast ? `Remove ${item.name} from pack last` : `Mark ${item.name} as pack last`}
             >
               <Sunrise className="w-3.5 h-3.5" />
             </button>
             <button
               onClick={() => handleDelete(item.id, item.categoryId, item.packingListId)}
-              className="text-red-400 hover:text-red-600 text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded px-1"
+              className="text-red-400 hover:text-red-600 text-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 rounded px-1"
               aria-label={`Remove ${item.name} from packing list`}
             >
               <X className="w-4 h-4" />


### PR DESCRIPTION
💡 What:
Added descriptive `aria-label`s and explicit `focus-visible` utility classes (e.g., `focus-visible:ring-2`, `focus-visible:ring-blue-500`) to the icon-only buttons in the packing list section, specifically for the note editing state (Save, Cancel) and hover-revealed actions (Add/Edit Note, Pack Last, Delete).

🎯 Why:
To ensure keyboard and screen reader accessibility. Hover-revealed and inline icon-only buttons frequently lack accessible names and distinct keyboard focus indicators, making them undiscoverable or unusable for non-mouse users.

📸 Before/After:
Before: Icon-only buttons relied on `title` or surrounding text for context, and used general `focus:` or simply `hover:` for interaction, meaning keyboard tab navigation might land on them without a visible ring, and screen readers might announce them as unlabelled buttons.
After: All icon-only buttons in these clusters explicitly declare `aria-label` (e.g., `aria-label="Save note for Camera"`) and show strong, themed focus rings (using `focus-visible:ring-*` classes) only when focused via keyboard.

♿ Accessibility:
- Improves screen reader support by contextualizing each button to the specific packing list item (e.g., "Remove Camera from packing list").
- Fixes keyboard navigation discoverability by ensuring `focus-visible` rings show up even for hover-revealed buttons.

---
*PR created automatically by Jules for task [3465304857709428941](https://jules.google.com/task/3465304857709428941) started by @mvng*