### PR TITLE
🔍 Scout: Fix Open Graph URL inheritance & implement canonical URLs

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,6 @@
 ## 2025-02-23 - [Dynamic Metadata for Shared Links]
 **Learning:** Next.js App Router allows exporting a `generateMetadata` function from Server Components (like `app/claim/[token]/page.tsx`) to dynamically set Open Graph and Twitter card metadata based on database content. This is crucial for improving link unfurling and CTR on external-facing shared pages.
 **Action:** Always check public-facing share/claim pages for missing dynamic metadata and implement `generateMetadata` with a `try/catch` fallback to ensure robust SSR.
+## 2024-07-05 - [Hardcoded og:url in Root Layout]
+**Learning:** In Next.js App Router, hardcoding `openGraph: { url: '...' }` in the root `app/layout.tsx` causes all child pages to incorrectly inherit the homepage's Open Graph URL for social sharing.
+**Action:** Rely on defining a global `metadataBase` combined with page-specific `alternates: { canonical: '...' }`, which allows Next.js to automatically and correctly populate the `og:url` for every page.

--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -7,6 +7,9 @@ export const metadata: Metadata = {
     title: 'Sign In or Create Account | Packwise',
     description: 'Log in to your Packwise account to view and manage your smart packing lists, or create a new account to get started.',
   },
+  alternates: {
+    canonical: '/login',
+  },
 }
 
 export default function LoginLayout({

--- a/app/claim/[token]/page.tsx
+++ b/app/claim/[token]/page.tsx
@@ -51,6 +51,9 @@ export async function generateMetadata({
         title,
         description,
       },
+      alternates: {
+        canonical: `/claim/${resolvedParams.token}`,
+      },
     }
   } catch (error) {
     return {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,6 @@ export const metadata: Metadata = {
     title: 'Packwise – Smart Packing Lists',
     description: 'Create smart packing lists for every trip.',
     type: 'website',
-    url: 'https://packwise-indol.vercel.app',
     siteName: 'Packwise',
     locale: 'en_US',
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,13 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+}
 
 export default async function HomePage() {
   const supabase = await createClient()

--- a/app/trip/[id]/layout.tsx
+++ b/app/trip/[id]/layout.tsx
@@ -40,6 +40,9 @@ export async function generateMetadata({
         title,
         description,
       },
+      alternates: {
+        canonical: `/trip/${resolvedParams.id}`,
+      },
     }
   } catch (error) {
     return {


### PR DESCRIPTION
💡 **What:** 
- Removed the hardcoded `url: 'https://packwise-indol.vercel.app'` from the `openGraph` object in the root `app/layout.tsx`.
- Added explicit `<link rel="canonical">` tags (via Next.js `alternates.canonical`) to the homepage, login page, shared claim page, and shared trip page.

🎯 **Why:** 
By default, Next.js metadata deeply merges objects. Having a hardcoded `og:url` in the root layout caused every subpage and dynamic route across the entire application to incorrectly inherit the homepage's URL as its Open Graph link. When users shared a specific trip (e.g., `/trip/123`), social platforms would preview and link to the homepage instead of the trip.
Additionally, defining explicit canonical URLs prevents search engines from indexing duplicate content if the same page is accessed via different parameters or tracking tags.

📊 **Impact:** 
- **Crawlability:** Prevents duplicate content indexing and solidifies the primary URI for each page.
- **CTR / Social Sharing:** Shared links for specific trips or claims will now correctly unfurl with the exact link to that resource, drastically improving click-through rates.

🔬 **Verification:** 
- Verified manually by inspecting the `<head>` generation of the modified routes.
- Passed `pnpm lint`.
- Passed full test suite (`pnpm test`).

🔗 **References:** 
- [Next.js Metadata alternates](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#alternates)
- [Next.js Open Graph metadata](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#opengraph)

---
*PR created automatically by Jules for task [9749502692377874002](https://jules.google.com/task/9749502692377874002) started by @mvng*