### PR TITLE
🎨 Palette: Improve accessibility of hover-revealed action buttons in TaskCard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-25 - Improve keyboard accessibility on hover-revealed action buttons
+**Learning:** Found that some action buttons use React state (`isHovered`) combined with `onMouseEnter` / `onMouseLeave` to control visibility. This pattern is inaccessible for keyboard users because `onMouseEnter` is tied to pointer events, and the items lack `focus-within` styling or `aria-label`s.
+**Action:** Always replace React state hover with CSS parent-child styling (e.g. `group-hover:opacity-100` alongside `focus-within:opacity-100`) to simplify the component and intrinsically support keyboard focus visibility. Additionally, ensure proper `aria-label`s are added.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,21 +20,19 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? `Mark "${task.title}" as incomplete` : `Mark "${task.title}" as complete`}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,18 +67,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
+            aria-label={`Edit "${task.title}"`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
+            aria-label={`Delete "${task.title}"`}
           >
             <Trash2 className="w-4 h-4" />
           </button>


### PR DESCRIPTION
💡 What: Replaced explicit React state hover with Tailwind CSS `group-hover` and `focus-within` for the action buttons in the TaskCard component. Added descriptive `aria-label`s and `focus-visible` outline styles.

🎯 Why: The previous implementation relied on pointer events (`onMouseEnter`) to reveal edit/delete actions, making them completely invisible and largely inaccessible to keyboard-only and screen reader users. The CSS-based approach intrinsically supports focus states, and the ARIA labels provide necessary context.

📸 Before/After: Visual changes are limited to a focus ring appearing on keyboard navigation. No layout changes occurred. 

♿ Accessibility: Ensures that users navigating via the `Tab` key can discover and use the action buttons on a TaskCard, and screen readers will announce their purpose.

---
*PR created automatically by Jules for task [3638095635342438145](https://jules.google.com/task/3638095635342438145) started by @mvng*