### PR TITLE
🎨 Palette: Add aria-labels and focus-visible states to CategorySection action buttons

### DIFF
--- a/components/inventory/CategorySection.tsx
+++ b/components/inventory/CategorySection.tsx
@@ -44,7 +44,7 @@ export default function CategorySection({
           <div className="relative">
             <button
               onClick={() => setShowMenu((v) => !v)}
-              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none"
+              className="text-gray-400 hover:text-gray-600 px-1 transition-colors text-lg leading-none focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
               aria-label="Category options"
             >
               •••
@@ -118,7 +118,8 @@ export default function CategorySection({
                 <button
                   onClick={() => onEditItem(item)}
                   title="Edit item"
-                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 >
                   <svg
                     className="w-3.5 h-3.5"
@@ -138,7 +139,8 @@ export default function CategorySection({
                   onClick={() => onDeleteItem(item.id)}
                   disabled={isPending}
                   title="Delete item"
-                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                  aria-label={`Delete ${item.name}`}
+                  className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
                 >
                   <svg
                     className="w-3.5 h-3.5"


### PR DESCRIPTION
💡 What: Added context-specific `aria-label` attributes to the hover-revealed 'Edit' and 'Delete' icon buttons in the Inventory `CategorySection`. Additionally, added explicit `focus-visible` states (`focus-visible:ring-2`, `focus-visible:ring-blue-500`, `focus-visible:ring-red-500`) to the 'Edit', 'Delete', and 'Category options (•••)' buttons.
🎯 Why: Icon-only buttons require descriptive `aria-label`s for screen reader users to understand their purpose (e.g. knowing *which* item is being deleted). Furthermore, buttons whose visibility is tied to mouse hover (`group-hover:opacity-100`) must have explicit keyboard focus outlines so that users navigating via the `Tab` key can see when they have focused on the hidden buttons.
📸 Before/After: Before, keyboard tab navigation over the items list would focus invisible buttons with no visual indication. Now, tabbing through the list reveals a clear, distinct outline ring on the focused actions.
♿ Accessibility: Improves WCAG compliance for Focus Visible (2.4.7) and Name, Role, Value (4.1.2).

---
*PR created automatically by Jules for task [6085771305254504414](https://jules.google.com/task/6085771305254504414) started by @mvng*