### PR TITLE
🔧 Fix: redirect to forked trip after login

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
+import { forkTrip } from '@/actions/trip.actions'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -11,6 +12,30 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [message, setMessage] = useState<string | null>(null)
+
+
+    const handleLoginSuccess = async () => {
+      const forkTripId = sessionStorage.getItem('fork_trip_after_login');
+      if (forkTripId) {
+        try {
+          const rawState = localStorage.getItem(`packwise_trip_${forkTripId}`);
+          const localStorageState = rawState ? JSON.parse(rawState) : null;
+
+          const result = await forkTrip(forkTripId, localStorageState);
+
+          if (result && result.success && result.tripId) {
+            sessionStorage.removeItem('fork_trip_after_login');
+            localStorage.removeItem(`packwise_trip_${forkTripId}`);
+            window.location.href = `/trip/${result.tripId}`;
+            return;
+          }
+        } catch (err) {
+          console.error('Failed to fork trip after login:', err);
+        }
+      }
+
+      window.location.href = '/dashboard';
+    };
 
   const handleAuth = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -36,8 +61,8 @@ export default function LoginPage() {
       // If email confirmation is disabled, signUp returns a valid session.
       // Redirect immediately to dashboard (the auth callback will upsert the Prisma User).
       if (data?.session) {
-        window.location.href = '/dashboard'
-        return
+        await handleLoginSuccess()
+      return
       }
 
       // Email confirmation is enabled — user must click the link in their email
@@ -49,8 +74,8 @@ export default function LoginPage() {
         setLoading(false)
         return
       }
-      window.location.href = '/dashboard'
-      return
+      await handleLoginSuccess()
+        return
     }
     setLoading(false)
   }


### PR DESCRIPTION
🐛 **Issue:** Closes #50 (Night 26 - Trip sharing: post-login fork workflow).
🔍 **Root Cause:** When an unauthenticated user attempts to fork a shared trip, they are correctly redirected to login, and the intent is stored in `sessionStorage`. However, the login page's `handleAuth` function ignored this intent and unconditionally redirected them to `/dashboard` upon a successful login or signup.
🛠️ **Fix:** Implemented a `handleLoginSuccess` helper in `app/(auth)/login/page.tsx`. This callback checks `sessionStorage` for the `fork_trip_after_login` intent. If present, it retrieves the local state, executes the `forkTrip` Server Action, clears the session/local storage, and directly redirects the user to their newly forked trip page. If the key is absent or the fork operation fails, it gracefully falls back to the `/dashboard` redirect.
✅ **Verification:** Verified via `pnpm lint` and `pnpm test`. Code Review confirmed the fallback logic safely handles errors and prevents the user from being stranded. Temporary scripts were cleaned up.
⚠️ **Notes:** To bypass aggressive Next.js auth state caching, `window.location.href` is used to enforce a full-page reload and ensure the correct server context.

---
*PR created automatically by Jules for task [7761120357384633846](https://jules.google.com/task/7761120357384633846) started by @mvng*