### PR TITLE
🎨 Palette: Improve accessibility of task action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-07-07 - Replace React hover state with CSS for accessible hover-revealed actions
+**Learning:** Found an accessibility issue pattern specific to this app's components where hover-revealed UI elements are managed with explicit component state (`isHovered` tied to `onMouseEnter`/`onMouseLeave`). This approach inherently misses keyboard focus visibility unless additional `onFocus`/`onBlur` listeners are wired up, making the actions invisible to keyboard navigators.
+**Action:** Use CSS parent-child styling like `group-hover:opacity-100` combined with `focus-within:opacity-100` to simplify the component and inherently support keyboard focus visibility without extra React state. Additionally, always ensure these action buttons have context-specific `aria-label`s and `focus-visible` utility classes.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,23 +20,21 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
-  const isDone = task.status === 'DONE'
+    const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`group relative p-4 rounded-xl border transition-all ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
+          aria-label={isDone ? `Mark "${task.title}" as pending` : `Mark "${task.title}" as done`}
         >
           {isDone ? <CheckCircle className="w-5 h-5" /> : <Circle className="w-5 h-5" />}
         </button>
@@ -70,18 +67,20 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             title="Edit task"
+            aria-label={`Edit "${task.title}"`}
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             title="Delete task"
+            aria-label={`Delete "${task.title}"`}
           >
             <Trash2 className="w-4 h-4" />
           </button>

--- a/components/TripPlanningAssistant/TaskForm.tsx
+++ b/components/TripPlanningAssistant/TaskForm.tsx
@@ -73,7 +73,8 @@ export default function TaskForm({ initialTask, onSave, onCancel, startDate }: T
         <button
           type="button"
           onClick={onCancel}
-          className="p-1 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors"
+          className="p-1 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+          aria-label="Close form"
         >
           <X className="w-5 h-5" />
         </button>


### PR DESCRIPTION
💡 **What:**
- Replaced explicit React `isHovered` state management with CSS `group`, `group-hover`, and `focus-within` in `TaskCard.tsx`.
- Added descriptive `aria-label`s and `focus-visible:ring-2` to the complete toggle, edit, and delete buttons.
- Added an `aria-label` and `focus-visible:ring-2` to the close button in `TaskForm.tsx`.
- Added a new learning entry to `.Jules/palette.md` noting the pattern.

🎯 **Why:**
The previous implementation used JavaScript `onMouseEnter` to reveal action buttons, making them completely invisible to keyboard navigators tabbing through the interface. Furthermore, the icon buttons lacked descriptions for screen readers. The CSS parent-child approach ensures focus visibility organically while being more performant.

📸 **Before/After:**
*(Visual changes captured during playwright verification script)* Keyboard-focused buttons now display the actions with a clear blue/red focus ring.

♿ **Accessibility:**
- Keyboard navigators can now discover and focus edit/delete buttons inside task cards.
- Screen readers will explicitly announce button intents (e.g. `Mark "Renew passport" as done`, `Close form`) instead of reading an unlabelled SVG.

---
*PR created automatically by Jules for task [12841168547442707440](https://jules.google.com/task/12841168547442707440) started by @mvng*