### PR TITLE
🎨 Palette: Improve accessibility of TaskCard action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-25 - Add accessible delete buttons to planning board items
 **Learning:** Found that delete/close actions revealed on hover often omit `aria-label` attributes and keyboard focus management since their visual state is tied to pointer events (e.g. `group-hover:opacity-100`).
 **Action:** Always ensure hover-revealed action buttons have descriptive `aria-label` attributes and explicit `focus-visible` utility classes so screen reader and keyboard users can discover and trigger them.
+## 2024-05-26 - Improve TaskCard action button accessibility
+**Learning:** Found that hover-revealed action buttons in `TaskCard` were managed with explicit component state (`isHovered`) and lacked `aria-label`s, breaking keyboard navigation.
+**Action:** Use CSS parent-child styling like `group-hover:opacity-100` combined with `focus-within:opacity-100` instead of explicit component state to simplify the component and inherently support keyboard focus visibility, and ensure `aria-label`s and `focus-visible` rings are applied.

--- a/components/TripPlanningAssistant/TaskCard.tsx
+++ b/components/TripPlanningAssistant/TaskCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Calendar, Trash2, Edit2, Bell, CheckCircle, Circle, Smartphone, Mail, Calendar as CalendarIcon } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 
@@ -21,21 +20,19 @@ interface TaskCardProps {
 }
 
 export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: TaskCardProps) {
-  const [isHovered, setIsHovered] = useState(false)
   const isDone = task.status === 'DONE'
 
   return (
     <div
-      className={`relative p-4 rounded-xl border transition-all ${
+      className={`relative p-4 rounded-xl border transition-all group ${
         isDone ? 'bg-gray-50 border-gray-100 opacity-75' : 'bg-white border-gray-200 shadow-sm hover:shadow-md'
       }`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
       <div className="flex items-start gap-3">
         <button
           onClick={() => onToggleStatus(task.id, task.status)}
-          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 transition-colors ${
+          aria-label={isDone ? "Mark as pending" : "Mark as done"}
+          className={`mt-1 flex-shrink-0 text-gray-400 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-full transition-colors ${
             isDone ? 'text-green-500 hover:text-green-600' : ''
           }`}
         >
@@ -70,17 +67,19 @@ export default function TaskCard({ task, onToggleStatus, onDelete, onEdit }: Tas
           </div>
         </div>
 
-        <div className={`flex items-center gap-1 transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
           <button
             onClick={() => onEdit(task)}
-            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-blue-600 rounded-md hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors"
+            aria-label="Edit task"
             title="Edit task"
           >
             <Edit2 className="w-4 h-4" />
           </button>
           <button
             onClick={() => onDelete(task.id)}
-            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 transition-colors"
+            className="p-1.5 text-gray-400 hover:text-red-600 rounded-md hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 transition-colors"
+            aria-label="Delete task"
             title="Delete task"
           >
             <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
### 💡 What:
Replaced the React-driven `isHovered` state (managed by `onMouseEnter` / `onMouseLeave`) with Tailwind's `group`, `group-hover:opacity-100`, and `focus-within:opacity-100` for the action buttons in the `TaskCard` component. Added clear `aria-label`s to the Check (Status Toggle), Edit, and Delete buttons, and implemented `focus-visible` outline rings.

### 🎯 Why:
Hover-revealed interactive elements are inherently inaccessible to keyboard users unless they are explicitly focusable. The `isHovered` React state entirely hid the buttons from the DOM visually (opacity 0) without triggering on keyboard focus. Moving to CSS pseudo-classes ensures the buttons naturally reveal themselves when tabbed into by a keyboard or screen reader user.

### 📸 Before/After:
Before: Edit and Delete buttons were invisible and untabbable without a mouse hover. Toggle button lacked an `aria-label`.
After: Action buttons reveal securely via `focus-within` when tabbed into, and focus outlines (blue for edit/toggle, red for delete) make it highly obvious which action is queued up.

### ♿ Accessibility:
- Action buttons are now fully keyboard accessible.
- Screen readers will now announce "Mark as done" / "Mark as pending", "Edit task", and "Delete task" rather than empty buttons.

---
*PR created automatically by Jules for task [3551031626446200223](https://jules.google.com/task/3551031626446200223) started by @mvng*